### PR TITLE
MODCONSKC-8: support sidecar system user approach

### DIFF
--- a/src/main/java/org/folio/consortia/FolioConsortiaApplication.java
+++ b/src/main/java/org/folio/consortia/FolioConsortiaApplication.java
@@ -1,6 +1,5 @@
 package org.folio.consortia;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
@@ -9,13 +8,7 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 @EnableFeignClients
 public class FolioConsortiaApplication {
 
-  public static final String SYSTEM_USER_PASSWORD = "SYSTEM_USER_PASSWORD";
-
   public static void main(String[] args) {
-    if (StringUtils.isEmpty(System.getenv(SYSTEM_USER_PASSWORD))) {
-      throw new IllegalArgumentException("Required environment variable is missing: " + SYSTEM_USER_PASSWORD);
-    }
     SpringApplication.run(FolioConsortiaApplication.class, args);
   }
-
 }

--- a/src/main/java/org/folio/consortia/repository/UserTenantRepository.java
+++ b/src/main/java/org/folio/consortia/repository/UserTenantRepository.java
@@ -48,4 +48,6 @@ public interface UserTenantRepository extends JpaRepository<UserTenantEntity, UU
   @Modifying
   @Query("DELETE FROM UserTenantEntity ut WHERE ut.userId NOT IN (SELECT ut.userId FROM UserTenantEntity ut WHERE ut.userId= ?1 AND ut.isPrimary=true) AND ut.userId= ?1")
   void deleteOrphansByUserIdAndIsPrimaryFalse(UUID userId);
+
+  boolean existsByUsernameAndTenantIdAndIsPrimaryTrue(String username, String tenantId);
 }

--- a/src/main/java/org/folio/consortia/service/UserTenantService.java
+++ b/src/main/java/org/folio/consortia/service/UserTenantService.java
@@ -1,7 +1,6 @@
 package org.folio.consortia.service;
 
 import java.util.UUID;
-
 import org.folio.consortia.domain.dto.UserTenant;
 import org.folio.consortia.domain.dto.UserTenantCollection;
 import org.folio.consortia.domain.entity.TenantEntity;
@@ -131,4 +130,12 @@ public interface UserTenantService {
    * @param userId id of user.
    */
   void deleteShadowUsers(UUID userId);
+
+  /**
+   * Check if user has primary affiliation.
+   *
+   * @param username the username
+   * @param tenantId the tenant id
+   */
+  boolean userHasPrimaryAffiliationByUsernameAndTenantId(String username, String tenantId);
 }

--- a/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
@@ -281,8 +281,8 @@ public class PublicationServiceImpl implements PublicationService {
       throw new PublicationException(PublicationException.TENANT_LIST_EMPTY);
     }
     tenantService.checkTenantsAndConsortiumExistsOrThrow(consortiumId, List.copyOf(publication.getTenants()));
+
     // condition to support eureka system user approach
-    var userAffiliated = userTenantService.checkUserIfHasPrimaryAffiliationByUserId(consortiumId, context.getUserId().toString());
     if (context.getUserId() == null) {
       var userExists = userTenantService.userHasPrimaryAffiliationByUsernameAndTenantId(SYSTEM_USER_NAME, context.getTenantId());
       if (!userExists) {
@@ -290,6 +290,8 @@ public class PublicationServiceImpl implements PublicationService {
       }
       return;
     }
+
+    var userAffiliated = userTenantService.checkUserIfHasPrimaryAffiliationByUserId(consortiumId, context.getUserId().toString());
     if (!userAffiliated) {
       throw new PublicationException(PublicationException.PRIMARY_AFFILIATION_NOT_EXISTS);
     }

--- a/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
@@ -281,19 +281,17 @@ public class PublicationServiceImpl implements PublicationService {
       throw new PublicationException(PublicationException.TENANT_LIST_EMPTY);
     }
     tenantService.checkTenantsAndConsortiumExistsOrThrow(consortiumId, List.copyOf(publication.getTenants()));
-    // condition check to support eureka system user approach
+    // condition to support eureka system user approach
+    var userAffiliated = userTenantService.checkUserIfHasPrimaryAffiliationByUserId(consortiumId, context.getUserId().toString());
     if (context.getUserId() == null) {
-      var userExists =
-        userTenantService.userHasPrimaryAffiliationByUsernameAndTenantId(SYSTEM_USER_NAME, context.getTenantId());
+      var userExists = userTenantService.userHasPrimaryAffiliationByUsernameAndTenantId(SYSTEM_USER_NAME, context.getTenantId());
       if (!userExists) {
         throw new PublicationException(PublicationException.PRIMARY_AFFILIATION_NOT_EXISTS);
       }
-    } else {
-      var userAffiliated =
-        userTenantService.checkUserIfHasPrimaryAffiliationByUserId(consortiumId, context.getUserId().toString());
-      if (!userAffiliated) {
-        throw new PublicationException(PublicationException.PRIMARY_AFFILIATION_NOT_EXISTS);
-      }
+      return;
+    }
+    if (!userAffiliated) {
+      throw new PublicationException(PublicationException.PRIMARY_AFFILIATION_NOT_EXISTS);
     }
   }
 

--- a/src/main/java/org/folio/consortia/service/impl/UserTenantServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/UserTenantServiceImpl.java
@@ -195,7 +195,8 @@ public class UserTenantServiceImpl implements UserTenantService {
   @Override
   public boolean checkUserIfHasPrimaryAffiliationByUserId(UUID consortiumId, String userId) {
     consortiumService.checkConsortiumExistsOrThrow(consortiumId);
-    var optionalUserTenant = userTenantRepository.findByUserIdAndIsPrimaryTrue(UUID.fromString(userId));
+    Optional<UserTenantEntity> optionalUserTenant = userTenantRepository
+      .findByUserIdAndIsPrimaryTrue(UUID.fromString(userId));
     return optionalUserTenant.isPresent();
   }
 

--- a/src/main/java/org/folio/consortia/service/impl/UserTenantServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/UserTenantServiceImpl.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.folio.consortia.domain.dto.PermissionUser;
 import org.folio.consortia.domain.dto.User;
 import org.folio.consortia.domain.dto.UserTenant;
 import org.folio.consortia.domain.dto.UserTenantCollection;
@@ -196,8 +195,7 @@ public class UserTenantServiceImpl implements UserTenantService {
   @Override
   public boolean checkUserIfHasPrimaryAffiliationByUserId(UUID consortiumId, String userId) {
     consortiumService.checkConsortiumExistsOrThrow(consortiumId);
-    Optional<UserTenantEntity> optionalUserTenant = userTenantRepository
-      .findByUserIdAndIsPrimaryTrue(UUID.fromString(userId));
+    var optionalUserTenant = userTenantRepository.findByUserIdAndIsPrimaryTrue(UUID.fromString(userId));
     return optionalUserTenant.isPresent();
   }
 
@@ -302,6 +300,11 @@ public class UserTenantServiceImpl implements UserTenantService {
 
       userTenantRepository.deleteOrphansByUserIdAndIsPrimaryFalse(userId);
     }
+  }
+
+  @Override
+  public boolean userHasPrimaryAffiliationByUsernameAndTenantId(String username, String tenantId) {
+    return userTenantRepository.existsByUsernameAndTenantIdAndIsPrimaryTrue(username, tenantId);
   }
 
   private UserTenantEntity toEntity(UserTenant userTenantDto, UUID consortiumId, User user) {

--- a/src/test/java/org/folio/consortia/service/UserTenantServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/UserTenantServiceTest.java
@@ -492,11 +492,6 @@ class UserTenantServiceTest {
   }
 
   @Test
-  void checkUserIfHasPrimaryAffiliationByUserId_positive_systemUserContextWithoutUserId() {
-    doNothing().when(consortiumService).checkConsortiumExistsOrThrow(any());
-  }
-
-  @Test
   void shouldFailWhileDeletingPrimaryAffiliation() {
     UUID userId = UUID.randomUUID();
     String tenantId = "dikue";

--- a/src/test/java/org/folio/consortia/service/UserTenantServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/UserTenantServiceTest.java
@@ -1,5 +1,6 @@
 package org.folio.consortia.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.folio.consortia.utils.EntityUtils.RANDOM_USER_ID;
 import static org.folio.consortia.utils.EntityUtils.createUserEntity;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -491,6 +492,11 @@ class UserTenantServiceTest {
   }
 
   @Test
+  void checkUserIfHasPrimaryAffiliationByUserId_positive_systemUserContextWithoutUserId() {
+    doNothing().when(consortiumService).checkConsortiumExistsOrThrow(any());
+  }
+
+  @Test
   void shouldFailWhileDeletingPrimaryAffiliation() {
     UUID userId = UUID.randomUUID();
     String tenantId = "dikue";
@@ -591,6 +597,14 @@ class UserTenantServiceTest {
     var result = userTenantService.checkUserIfHasPrimaryAffiliationByUserId(UUID.randomUUID(), String.valueOf(UUID.randomUUID()));
 
     assertTrue(result);
+  }
+
+  @Test
+  void userHasPrimaryAffiliationByUsernameAndTenantId_positive() {
+    when(userTenantRepository.existsByUsernameAndTenantIdAndIsPrimaryTrue(anyString(), anyString())).thenReturn(true);
+
+    var result = userTenantService.userHasPrimaryAffiliationByUsernameAndTenantId("username", "tenantId");
+    assertThat(result).isTrue();
   }
 
   private UserTenantEntity createUserTenantEntity(UUID associationId, UUID userId, String username, String tenantId) {


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/MODCONSKC-8
The module doesn't support 'eureka' system user approach in setting instance creation flow. It should be fixed.

## Approach

- add validation based on system user name and tenantId
- add test

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
