### PR TITLE
MODCONSKC-11 Bug - set update metadata upon record creation

### DIFF
--- a/src/main/java/org/folio/consortia/FolioConsortiaApplication.java
+++ b/src/main/java/org/folio/consortia/FolioConsortiaApplication.java
@@ -2,10 +2,8 @@ package org.folio.consortia;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
-@EnableFeignClients
 public class FolioConsortiaApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/org/folio/consortia/config/AppConfig.java
+++ b/src/main/java/org/folio/consortia/config/AppConfig.java
@@ -1,8 +1,13 @@
 package org.folio.consortia.config;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import org.folio.consortia.domain.converter.ConsortiumConverter;
 import org.folio.consortia.domain.converter.TenantEntityToTenantConverter;
 import org.folio.consortia.domain.converter.UserTenantConverter;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -13,13 +18,9 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-
 @Configuration
 @EnableAsync
+@EnableFeignClients("org.folio.consortia")
 public class AppConfig implements WebMvcConfigurer {
 
   @Override

--- a/src/main/java/org/folio/consortia/config/FolioAuditorAware.java
+++ b/src/main/java/org/folio/consortia/config/FolioAuditorAware.java
@@ -14,7 +14,7 @@ import java.util.UUID;
  * getCurrentAuditor() is needed to get current logged in user.
  */
 @Configuration
-@EnableJpaAuditing(modifyOnCreate = false)
+@EnableJpaAuditing
 @RequiredArgsConstructor
 public class FolioAuditorAware implements AuditorAware<UUID> {
 

--- a/src/main/java/org/folio/consortia/domain/entity/base/AuditableEntity.java
+++ b/src/main/java/org/folio/consortia/domain/entity/base/AuditableEntity.java
@@ -31,7 +31,7 @@ public abstract class AuditableEntity {
   private UUID createdBy;
 
   @LastModifiedDate
-  @Column(name = "updated_date")
+  @Column(name = "updated_date", nullable = false)
   private LocalDateTime updatedDate;
 
   @LastModifiedBy

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -11,4 +11,5 @@
   <include file="changes/create-publish-coordinator-tables.xml" relativeToChangelogFile="true"/>
   <include file="changes/create-sharing-instance-action-table.xml" relativeToChangelogFile="true"/>
   <include file="changes/create-sharing-setting-table.xml" relativeToChangelogFile="true"/>
+  <include file="changes/set-default-for-updated-date.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/set-default-for-updated-date.xml
+++ b/src/main/resources/db/changelog/changes/set-default-for-updated-date.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.17.xsd">
+
+  <changeSet id="MODCONSKC-11@@update-date-with-default-in-consortia-configuration" author="dmtkachenko">
+    <addDefaultValue tableName="consortia_configuration" columnName="updated_date" defaultValueComputed="now()"/>
+
+    <update tableName="consortia_configuration">
+      <column name="updated_date" valueComputed="created_date"/>
+      <where>updated_date is NULL</where>
+    </update>
+
+    <addNotNullConstraint tableName="consortia_configuration" columnName="updated_date"/>
+  </changeSet>
+
+  <changeSet id="MODCONSKC-11@@update-date-with-default-in-consortium" author="dmtkachenko">
+    <addDefaultValue tableName="consortium" columnName="updated_date" defaultValueComputed="now()"/>
+
+    <update tableName="consortium">
+      <column name="updated_date" valueComputed="created_date"/>
+      <where>updated_date is NULL</where>
+    </update>
+
+    <addNotNullConstraint tableName="consortium" columnName="updated_date"/>
+  </changeSet>
+
+  <changeSet id="MODCONSKC-11@@update-date-with-default-in-pc-state" author="dmtkachenko">
+    <addDefaultValue tableName="pc_state" columnName="updated_date" defaultValueComputed="now()"/>
+
+    <update tableName="pc_state">
+      <column name="updated_date" valueComputed="created_date"/>
+      <where>updated_date is NULL</where>
+    </update>
+
+    <addNotNullConstraint tableName="pc_state" columnName="updated_date"/>
+  </changeSet>
+
+  <changeSet id="MODCONSKC-11@@update-date-with-default-in-pc-tenant-request" author="dmtkachenko">
+    <addDefaultValue tableName="pc_tenant_request" columnName="updated_date" defaultValueComputed="now()"/>
+
+    <update tableName="pc_tenant_request">
+      <column name="updated_date" valueComputed="created_date"/>
+      <where>updated_date is NULL</where>
+    </update>
+
+    <addNotNullConstraint tableName="pc_tenant_request" columnName="updated_date"/>
+  </changeSet>
+
+  <changeSet id="MODCONSKC-11@@update-date-with-default-in-sharing-instance" author="dmtkachenko">
+    <addDefaultValue tableName="sharing_instance" columnName="updated_date" defaultValueComputed="now()"/>
+
+    <update tableName="sharing_instance">
+      <column name="updated_date" valueComputed="created_date"/>
+      <where>updated_date is NULL</where>
+    </update>
+
+    <addNotNullConstraint tableName="sharing_instance" columnName="updated_date"/>
+  </changeSet>
+
+  <changeSet id="MODCONSKC-11@@update-date-with-default-in-sharing-setting" author="dmtkachenko">
+    <addDefaultValue tableName="sharing_setting" columnName="updated_date" defaultValueComputed="now()"/>
+
+    <update tableName="sharing_setting">
+      <column name="updated_date" valueComputed="created_date"/>
+      <where>updated_date is NULL</where>
+    </update>
+
+    <addNotNullConstraint tableName="sharing_setting" columnName="updated_date"/>
+  </changeSet>
+
+  <changeSet id="MODCONSKC-11@@update-date-with-default-in-tenant" author="dmtkachenko">
+    <addDefaultValue tableName="tenant" columnName="updated_date" defaultValueComputed="now()"/>
+
+    <update tableName="tenant">
+      <column name="updated_date" valueComputed="created_date"/>
+      <where>updated_date is NULL</where>
+    </update>
+
+    <addNotNullConstraint tableName="tenant" columnName="updated_date"/>
+  </changeSet>
+
+  <changeSet id="MODCONSKC-11@@update-date-with-default-in-user-tenant" author="dmtkachenko">
+    <addDefaultValue tableName="user_tenant" columnName="updated_date" defaultValueComputed="now()"/>
+
+    <update tableName="user_tenant">
+      <column name="updated_date" valueComputed="created_date"/>
+      <where>updated_date is NULL</where>
+    </update>
+
+    <addNotNullConstraint tableName="user_tenant" columnName="updated_date"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/folio/consortia/repository/ConsortiaConfigurationRepositoryTest.java
+++ b/src/test/java/org/folio/consortia/repository/ConsortiaConfigurationRepositoryTest.java
@@ -1,0 +1,32 @@
+package org.folio.consortia.repository;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.folio.consortia.utils.EntityUtils.CENTRAL_TENANT_ID;
+import static org.folio.consortia.utils.EntityUtils.createConsortiaConfigurationEntity;
+
+import java.time.LocalDateTime;
+import org.folio.consortia.domain.entity.ConsortiaConfigurationEntity;
+import org.folio.consortia.support.BaseRepositoryTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class ConsortiaConfigurationRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired
+  private ConsortiaConfigurationRepository repository;
+
+  @Test
+  void create_positive_updateDateAndCreatedDateNotNull() {
+    var entity = createConsortiaConfigurationEntity(CENTRAL_TENANT_ID);
+    entity.setId(null);
+    var now = LocalDateTime.now();
+
+    var saved = repository.saveAndFlush(entity);
+
+    var stored = entityManager.find(ConsortiaConfigurationEntity.class, saved.getId());
+    assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+  }
+}

--- a/src/test/java/org/folio/consortia/repository/ConsortiumRepositoryTest.java
+++ b/src/test/java/org/folio/consortia/repository/ConsortiumRepositoryTest.java
@@ -1,0 +1,31 @@
+package org.folio.consortia.repository;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.folio.consortia.utils.EntityUtils.CONSORTIUM_ID;
+import static org.folio.consortia.utils.EntityUtils.createConsortiumEntity;
+
+import java.time.LocalDateTime;
+import org.folio.consortia.domain.entity.ConsortiumEntity;
+import org.folio.consortia.support.BaseRepositoryTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class ConsortiumRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired
+  private ConsortiumRepository repository;
+
+  @Test
+  void create_positive_updateDateAndCreatedDateNotNull() {
+    var entity = createConsortiumEntity(CONSORTIUM_ID.toString(), "Consortium");
+    var now = LocalDateTime.now();
+
+    var saved = repository.saveAndFlush(entity);
+
+    var stored = entityManager.find(ConsortiumEntity.class, saved.getId());
+    assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+  }
+}

--- a/src/test/java/org/folio/consortia/repository/PublicationStatusRepositoryTest.java
+++ b/src/test/java/org/folio/consortia/repository/PublicationStatusRepositoryTest.java
@@ -1,0 +1,31 @@
+package org.folio.consortia.repository;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.folio.consortia.utils.EntityUtils.createPublicationStatusEntity;
+
+import java.time.LocalDateTime;
+import org.folio.consortia.domain.dto.PublicationStatus;
+import org.folio.consortia.domain.entity.PublicationStatusEntity;
+import org.folio.consortia.support.BaseRepositoryTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class PublicationStatusRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired
+  private PublicationStatusRepository repository;
+
+  @Test
+  void create_positive_updateDateAndCreatedDateNotNull() {
+    var entity = createPublicationStatusEntity(PublicationStatus.COMPLETE);
+    var now = LocalDateTime.now();
+
+    var saved = repository.saveAndFlush(entity);
+
+    var stored = entityManager.find(PublicationStatusEntity.class, saved.getId());
+    assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+  }
+}

--- a/src/test/java/org/folio/consortia/repository/PublicationTenantRequestRepositoryTest.java
+++ b/src/test/java/org/folio/consortia/repository/PublicationTenantRequestRepositoryTest.java
@@ -1,0 +1,38 @@
+package org.folio.consortia.repository;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.folio.consortia.utils.EntityUtils.createPublicationStatusEntity;
+import static org.folio.consortia.utils.EntityUtils.createPublicationTenantRequestEntity;
+
+import java.time.LocalDateTime;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.folio.consortia.domain.dto.PublicationStatus;
+import org.folio.consortia.domain.entity.PublicationTenantRequestEntity;
+import org.folio.consortia.support.BaseRepositoryTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class PublicationTenantRequestRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired
+  private PublicationTenantRequestRepository repository;
+
+  @Test
+  void create_positive_updateDateAndCreatedDateNotNull() {
+    var statusEntity = createPublicationStatusEntity(PublicationStatus.COMPLETE);
+    entityManager.persistAndFlush(statusEntity);
+
+    var entity = createPublicationTenantRequestEntity(statusEntity, "test",
+      PublicationStatus.COMPLETE, 0);
+    entity.setRequestUrl(RandomStringUtils.randomAlphanumeric(10));
+    var now = LocalDateTime.now();
+
+    var saved = repository.saveAndFlush(entity);
+
+    var stored = entityManager.find(PublicationTenantRequestEntity.class, saved.getId());
+    assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+  }
+}

--- a/src/test/java/org/folio/consortia/repository/SharingInstanceRepositoryTest.java
+++ b/src/test/java/org/folio/consortia/repository/SharingInstanceRepositoryTest.java
@@ -1,0 +1,33 @@
+package org.folio.consortia.repository;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.folio.consortia.utils.EntityUtils.createSharingInstanceEntity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.folio.consortia.domain.dto.Status;
+import org.folio.consortia.domain.entity.SharingInstanceEntity;
+import org.folio.consortia.support.BaseRepositoryTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class SharingInstanceRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired
+  private SharingInstanceRepository repository;
+
+  @Test
+  void create_positive_updateDateAndCreatedDateNotNull() {
+    var entity = createSharingInstanceEntity(UUID.randomUUID(), UUID.randomUUID(), "test1", "test2");
+    entity.setStatus(Status.COMPLETE);
+    var now = LocalDateTime.now();
+
+    var saved = repository.saveAndFlush(entity);
+
+    var stored = entityManager.find(SharingInstanceEntity.class, saved.getId());
+    assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+  }
+}

--- a/src/test/java/org/folio/consortia/repository/SharingSettingRepositoryTest.java
+++ b/src/test/java/org/folio/consortia/repository/SharingSettingRepositoryTest.java
@@ -1,0 +1,31 @@
+package org.folio.consortia.repository;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.folio.consortia.utils.EntityUtils.createSharingSettingEntity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.folio.consortia.domain.entity.SharingSettingEntity;
+import org.folio.consortia.support.BaseRepositoryTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class SharingSettingRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired
+  private SharingSettingRepository repository;
+
+  @Test
+  void create_positive_updateDateAndCreatedDateNotNull() {
+    var entity = createSharingSettingEntity(UUID.randomUUID(), "test");
+    var now = LocalDateTime.now();
+
+    var saved = repository.saveAndFlush(entity);
+
+    var stored = entityManager.find(SharingSettingEntity.class, saved.getId());
+    assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+  }
+}

--- a/src/test/java/org/folio/consortia/repository/TenantDetailsRepositoryTest.java
+++ b/src/test/java/org/folio/consortia/repository/TenantDetailsRepositoryTest.java
@@ -1,0 +1,37 @@
+package org.folio.consortia.repository;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.folio.consortia.utils.EntityUtils.CENTRAL_TENANT_ID;
+import static org.folio.consortia.utils.EntityUtils.CONSORTIUM_ID;
+import static org.folio.consortia.utils.EntityUtils.createConsortiumEntity;
+import static org.folio.consortia.utils.EntityUtils.createTenantDetailsEntity;
+
+import java.time.LocalDateTime;
+import org.folio.consortia.domain.entity.TenantDetailsEntity;
+import org.folio.consortia.support.BaseRepositoryTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class TenantDetailsRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired
+  private TenantDetailsRepository repository;
+
+  @Test
+  void create_positive_updateDateAndCreatedDateNotNull() {
+    var consortium = createConsortiumEntity(CONSORTIUM_ID.toString(), CENTRAL_TENANT_ID);
+    entityManager.persistAndFlush(consortium);
+
+    var entity = createTenantDetailsEntity();
+    entity.setConsortiumId(consortium.getId());
+    var now = LocalDateTime.now();
+
+    var saved = repository.saveAndFlush(entity);
+
+    var stored = entityManager.find(TenantDetailsEntity.class, saved.getId());
+    assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+  }
+}

--- a/src/test/java/org/folio/consortia/repository/TenantRepositoryTest.java
+++ b/src/test/java/org/folio/consortia/repository/TenantRepositoryTest.java
@@ -1,0 +1,37 @@
+package org.folio.consortia.repository;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.folio.consortia.utils.EntityUtils.CENTRAL_TENANT_ID;
+import static org.folio.consortia.utils.EntityUtils.CONSORTIUM_ID;
+import static org.folio.consortia.utils.EntityUtils.createConsortiumEntity;
+import static org.folio.consortia.utils.EntityUtils.createTenantEntity;
+
+import java.time.LocalDateTime;
+import org.folio.consortia.domain.entity.TenantEntity;
+import org.folio.consortia.support.BaseRepositoryTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class TenantRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired
+  private TenantRepository repository;
+
+  @Test
+  void create_positive_updateDateAndCreatedDateNotNull() {
+    var consortium = createConsortiumEntity(CONSORTIUM_ID.toString(), CENTRAL_TENANT_ID);
+    entityManager.persistAndFlush(consortium);
+
+    var entity = createTenantEntity();
+    entity.setConsortiumId(consortium.getId());
+    var now = LocalDateTime.now();
+
+    var saved = repository.saveAndFlush(entity);
+
+    var stored = entityManager.find(TenantEntity.class, saved.getId());
+    assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+  }
+}

--- a/src/test/java/org/folio/consortia/repository/UserTenantRepositoryTest.java
+++ b/src/test/java/org/folio/consortia/repository/UserTenantRepositoryTest.java
@@ -1,0 +1,43 @@
+package org.folio.consortia.repository;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.folio.consortia.utils.EntityUtils.CENTRAL_TENANT_ID;
+import static org.folio.consortia.utils.EntityUtils.CONSORTIUM_ID;
+import static org.folio.consortia.utils.EntityUtils.createConsortiumEntity;
+import static org.folio.consortia.utils.EntityUtils.createTenantEntity;
+import static org.folio.consortia.utils.EntityUtils.createUserTenantEntity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.folio.consortia.domain.entity.UserTenantEntity;
+import org.folio.consortia.support.BaseRepositoryTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class UserTenantRepositoryTest extends BaseRepositoryTest {
+
+  @Autowired
+  private UserTenantRepository repository;
+
+  @Test
+  void create_positive_updateDateAndCreatedDateNotNull() {
+    var consortium = createConsortiumEntity(CONSORTIUM_ID.toString(), CENTRAL_TENANT_ID);
+    entityManager.persistAndFlush(consortium);
+
+    var tenant = createTenantEntity();
+    tenant.setConsortiumId(consortium.getId());
+    entityManager.persistAndFlush(tenant);
+
+    var entity = createUserTenantEntity(UUID.randomUUID());
+    entity.setTenant(tenant);
+    var now = LocalDateTime.now();
+
+    var saved = repository.saveAndFlush(entity);
+
+    var stored = entityManager.find(UserTenantEntity.class, saved.getId());
+    assertThat(stored.getCreatedDate()).isCloseTo(now, within(1, MINUTES));
+    assertThat(stored.getUpdatedDate()).isCloseTo(now, within(1, MINUTES));
+  }
+}

--- a/src/test/java/org/folio/consortia/support/BaseRepositoryTest.java
+++ b/src/test/java/org/folio/consortia/support/BaseRepositoryTest.java
@@ -1,0 +1,29 @@
+package org.folio.consortia.support;
+
+import static org.springframework.test.annotation.DirtiesContext.ClassMode.AFTER_CLASS;
+
+import lombok.extern.log4j.Log4j2;
+import org.folio.consortia.config.FolioAuditorAware;
+import org.folio.consortia.support.extension.EnablePostgresExtension;
+import org.folio.spring.FolioExecutionContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+
+@Log4j2
+@DataJpaTest
+@EnablePostgresExtension
+@DirtiesContext(classMode = AFTER_CLASS)
+@Import({FolioAuditorAware.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public abstract class BaseRepositoryTest {
+
+  @Autowired
+  protected TestEntityManager entityManager;
+  @MockBean
+  protected FolioExecutionContext folioExecutionContext;
+}

--- a/src/test/java/org/folio/consortia/support/extension/impl/PostgresContainerExtension.java
+++ b/src/test/java/org/folio/consortia/support/extension/impl/PostgresContainerExtension.java
@@ -6,10 +6,15 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 public class PostgresContainerExtension implements BeforeAllCallback, AfterAllCallback {
-  private static final String SPRING_PROPERTY_NAME = "spring.datasource.url";
-  private static final String POSTGRES_IMAGE = "postgres:12-alpine";
-  private static final PostgreSQLContainer<?> CONTAINER = new PostgreSQLContainer<>(POSTGRES_IMAGE)
-    .withDatabaseName("okapi_modules").withUsername("folio_admin").withPassword("folio_admin");
+  private static final String SPRING_DATASOURCE_URL = "spring.datasource.url";
+  private static final String SPRING_DATASOURCE_USERNAME = "spring.datasource.username";
+  private static final String SPRING_DATASOURCE_PASSWORD = "spring.datasource.password";
+
+  @SuppressWarnings("resource")
+  private static final PostgreSQLContainer<?> CONTAINER = new PostgreSQLContainer<>("postgres:12-alpine")
+    .withDatabaseName("okapi_modules")
+    .withUsername("folio_admin")
+    .withPassword("folio_admin");
 
   @Override
   public void beforeAll(ExtensionContext context) {
@@ -17,11 +22,15 @@ public class PostgresContainerExtension implements BeforeAllCallback, AfterAllCa
       CONTAINER.start();
     }
 
-    System.setProperty(SPRING_PROPERTY_NAME, CONTAINER.getJdbcUrl());
+    System.setProperty(SPRING_DATASOURCE_URL, CONTAINER.getJdbcUrl());
+    System.setProperty(SPRING_DATASOURCE_USERNAME, CONTAINER.getUsername());
+    System.setProperty(SPRING_DATASOURCE_PASSWORD, CONTAINER.getPassword());
   }
 
   @Override
   public void afterAll(ExtensionContext context) {
-    System.clearProperty(SPRING_PROPERTY_NAME);
+    System.clearProperty(SPRING_DATASOURCE_URL);
+    System.clearProperty(SPRING_DATASOURCE_USERNAME);
+    System.clearProperty(SPRING_DATASOURCE_PASSWORD);
   }
 }

--- a/src/test/java/org/folio/consortia/utils/EntityUtils.java
+++ b/src/test/java/org/folio/consortia/utils/EntityUtils.java
@@ -1,19 +1,15 @@
 package org.folio.consortia.utils;
 
-import org.folio.consortia.domain.entity.ConsortiaConfigurationEntity;
-import org.folio.consortia.domain.entity.ConsortiumEntity;
-import org.folio.consortia.domain.entity.PublicationStatusEntity;
-import org.folio.consortia.domain.entity.PublicationTenantRequestEntity;
-import org.folio.consortia.domain.entity.SharingInstanceEntity;
-import org.folio.consortia.domain.entity.TenantDetailsEntity;
-import org.folio.consortia.domain.entity.TenantEntity;
-import org.folio.consortia.domain.entity.UserTenantEntity;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
+import lombok.experimental.UtilityClass;
 import org.folio.consortia.domain.dto.ConsortiaConfiguration;
 import org.folio.consortia.domain.dto.Consortium;
 import org.folio.consortia.domain.dto.Personal;
@@ -31,14 +27,16 @@ import org.folio.consortia.domain.dto.TenantCollection;
 import org.folio.consortia.domain.dto.TenantDetails.SetupStatusEnum;
 import org.folio.consortia.domain.dto.User;
 import org.folio.consortia.domain.dto.UserTenant;
+import org.folio.consortia.domain.entity.ConsortiaConfigurationEntity;
+import org.folio.consortia.domain.entity.ConsortiumEntity;
+import org.folio.consortia.domain.entity.PublicationStatusEntity;
+import org.folio.consortia.domain.entity.PublicationTenantRequestEntity;
+import org.folio.consortia.domain.entity.SharingInstanceEntity;
+import org.folio.consortia.domain.entity.SharingSettingEntity;
+import org.folio.consortia.domain.entity.TenantDetailsEntity;
+import org.folio.consortia.domain.entity.TenantEntity;
+import org.folio.consortia.domain.entity.UserTenantEntity;
 import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class EntityUtils {
@@ -203,6 +201,22 @@ public class EntityUtils {
     sharingInstance.setCreatedDate(LocalDateTime.now());
     sharingInstance.setCreatedBy(UUID.fromString("dcfc317b-0d7c-4334-8656-596105fa6c99"));
     return sharingInstance;
+  }
+
+  public static PublicationStatusEntity createPublicationStatusEntity(PublicationStatus publicationStatus) {
+    var entity = new PublicationStatusEntity();
+    entity.setId(UUID.randomUUID());
+    entity.setStatus(publicationStatus);
+    entity.setTotalRecords(0);
+    return entity;
+  }
+
+  public static SharingSettingEntity createSharingSettingEntity(UUID settingId, String tenantId) {
+    var entity = new SharingSettingEntity();
+    entity.setId(UUID.randomUUID());
+    entity.setSettingId(settingId);
+    entity.setTenantId(tenantId);
+    return entity;
   }
 
   public static PublicationTenantRequestEntity createPublicationTenantRequestEntity(


### PR DESCRIPTION
## Purpose
It was recently discovered that when creating records (at least roles, but possibly other record types), only the ""createdBy"" and ""createdDate"" metadata is set.  Elsewhere in Folio, the ""updatedBy"" and ""updatedDate"" metadata is also set upon record creation (to the same values). 
US: [MODCONSKC-11](https://folio-org.atlassian.net/browse/MODCONSKC-11)

## Approach
* mark entity as modified upon creation (change auditing configuration)
* make updatedDate field non-null
* verify changes with repository tests

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
