### PR TITLE
Bump up applications-poc-tools dependencies to 1.5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,8 @@
     <folio-service-tools.version>4.0.1</folio-service-tools.version>
     <openapi-generator.version>7.8.0</openapi-generator.version>
     <mapstruct.version>1.6.0</mapstruct.version>
-    <applications-poc-tools.version>1.5.5</applications-poc-tools.version>
+    <applications-poc-tools.version>1.5.6</applications-poc-tools.version>
+    <commons-lang3.version>3.17.0</commons-lang3.version>
 
     <!-- test dependencies -->
     <wiremock-standalone.version>3.0.1</wiremock-standalone.version>


### PR DESCRIPTION
## Purpose
Bump up applications-poc-tools dependencies to 1.5.6 to support Hostname Verification for TLS connections
