### PR TITLE
MODCONSKC-7: adjust custom fields creation error handling

### DIFF
--- a/src/main/java/org/folio/consortia/controller/ErrorHandlingController.java
+++ b/src/main/java/org/folio/consortia/controller/ErrorHandlingController.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import org.folio.consortia.domain.dto.Error;
 import org.folio.consortia.domain.dto.Errors;
 import org.folio.consortia.exception.ConsortiumClientException;
+import org.folio.consortia.exception.CustomFieldCreationException;
 import org.folio.consortia.exception.InvalidTokenException;
 import org.folio.consortia.exception.UserAffiliationException;
 import org.folio.consortia.exception.PublicationException;
@@ -123,4 +124,10 @@ public class ErrorHandlingController {
     return new Errors().errors(errorList);
   }
 
+  @ExceptionHandler(CustomFieldCreationException.class)
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  public Errors handleCustomFieldCreationException(Exception e) {
+    log.error("Handle custom field creation exception", e);
+    return ErrorHelper.createInternalError(e.getMessage(), ErrorCode.INTERNAL_ERROR);
+  }
 }

--- a/src/main/java/org/folio/consortia/exception/CustomFieldCreationException.java
+++ b/src/main/java/org/folio/consortia/exception/CustomFieldCreationException.java
@@ -1,0 +1,8 @@
+package org.folio.consortia.exception;
+
+public class CustomFieldCreationException extends RuntimeException {
+
+  public CustomFieldCreationException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/folio/consortia/utils/ErrorHelper.java
+++ b/src/main/java/org/folio/consortia/utils/ErrorHelper.java
@@ -74,7 +74,8 @@ public class ErrorHelper {
     PUBLICATION_ERROR,
     PERMISSION_REQUIRED,
     BAD_GATEWAY,
-    UNAUTHORIZED
+    UNAUTHORIZED,
+    INTERNAL_ERROR
   }
 
 }

--- a/src/test/java/org/folio/consortia/controller/FolioTenantControllerTest.java
+++ b/src/test/java/org/folio/consortia/controller/FolioTenantControllerTest.java
@@ -23,7 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-public class FolioTenantControllerTest extends BaseIT {
+class FolioTenantControllerTest extends BaseIT {
 
   @MockBean
   CustomFieldService customFieldService;

--- a/src/test/java/org/folio/consortia/controller/FolioTenantControllerTest.java
+++ b/src/test/java/org/folio/consortia/controller/FolioTenantControllerTest.java
@@ -1,0 +1,61 @@
+package org.folio.consortia.controller;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.common.ClasspathFileSource;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.TemplateEngine;
+import java.util.ArrayList;
+import org.folio.consortia.base.BaseIT;
+import org.folio.consortia.domain.dto.CustomField;
+import org.folio.consortia.service.CustomFieldService;
+import org.folio.tenant.domain.dto.TenantAttributes;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+public class FolioTenantControllerTest extends BaseIT {
+
+  @MockBean
+  CustomFieldService customFieldService;
+
+  @BeforeAll
+  static void beforeAll(@Autowired MockMvc mockMvc) {
+    //override default tenant setup for integration tests
+    wireMockServer = new WireMockServer(wireMockConfig()
+      .port(WIRE_MOCK_PORT)
+      .extensions(
+        new ResponseTemplateTransformer(TemplateEngine.defaultTemplateEngine(), true, new ClasspathFileSource("/"),
+          new ArrayList<>())));
+
+    wireMockServer.start();
+  }
+
+  @Test
+  void enableTenant_negative_customFieldNotCreated() throws Exception {
+    when(customFieldService.getCustomFieldByName(anyString())).thenReturn(null);
+    doThrow(new RuntimeException("error")).when(customFieldService).createCustomField(any(CustomField.class));
+
+    mockMvc.perform(post("/_/tenant")
+        .headers(defaultHeaders())
+        .content(asJsonString(new TenantAttributes().moduleTo("mod-consortia-keycloak"))))
+      .andExpect(status().is(500));
+  }
+
+  @Test
+  void enableTenant_positive() throws Exception {
+    mockMvc.perform(post("/_/tenant")
+        .headers(defaultHeaders())
+        .content(asJsonString(new TenantAttributes().moduleTo("mod-consortia-keycloak"))))
+      .andExpect(status().is(204));
+  }
+}


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/MODCONSKC-7
During tenant initialization, custom fields are created for the tenant.  Presently, failure to create these custom fields does not cause the tenant initialization to fail.  The purpose of this story is to improve the visibility of this by enhancing error handling.

## Approach

- make custom filed creation synchronously
- return error if customer field creation failed
- add tests

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.

