### PR TITLE
MODCONSKC-32: move custom field creation to save tenant operation

### DIFF
--- a/src/main/java/org/folio/consortia/service/FolioTenantService.java
+++ b/src/main/java/org/folio/consortia/service/FolioTenantService.java
@@ -6,25 +6,16 @@ import liquibase.exception.LiquibaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.ObjectUtils;
 import org.folio.consortia.config.kafka.KafkaService;
 import org.folio.consortia.config.property.CustomFieldsRetryProperties;
-import org.folio.consortia.domain.dto.CustomField;
-import org.folio.consortia.domain.dto.CustomFieldType;
-import org.folio.consortia.exception.CustomFieldCreationException;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.exception.TenantUpgradeException;
 import org.folio.spring.liquibase.FolioSpringLiquibase;
 import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.folio.spring.service.TenantService;
 import org.folio.tenant.domain.dto.TenantAttributes;
-import org.jetbrains.annotations.Nullable;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.retry.RetryContext;
-import org.springframework.retry.backoff.FixedBackOffPolicy;
-import org.springframework.retry.policy.SimpleRetryPolicy;
-import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Service;
 
 @Log4j2
@@ -34,22 +25,13 @@ public class FolioTenantService extends TenantService {
 
   private static final String EXIST_SQL =
     "SELECT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = ?)";
+  private static final String TENANT_NAME_PARAMETER = "tenantname";
 
   private final KafkaService kafkaService;
   private final CustomFieldService customFieldService;
   private final FolioExecutionContext folioExecutionContext;
   private final SystemUserScopedExecutionService systemUserScopedExecutionService;
   private final CustomFieldsRetryProperties customFieldsRetryProperties;
-
-  private static final String ORIGINAL_TENANT_ID_NAME = "originalTenantId";
-  private static final String TENANT_NAME_PARAMETER = "tenantname";
-  private static final CustomField ORIGINAL_TENANT_ID_CUSTOM_FIELD = CustomField.builder()
-    .name(ORIGINAL_TENANT_ID_NAME)
-    .entityType("user")
-    .helpText("Id of tenant where user created originally")
-    .customFieldType(CustomFieldType.TEXTBOX_LONG)
-    .visible(false)
-    .build();
 
   public FolioTenantService(JdbcTemplate jdbcTemplate,
                             KafkaService kafkaService,
@@ -96,7 +78,6 @@ public class FolioTenantService extends TenantService {
   protected void afterTenantUpdate(TenantAttributes tenantAttributes) {
     try {
       kafkaService.createKafkaTopics();
-      createOriginalTenantIdCustomField();
     } catch (Exception e) {
       log.error(e.getMessage(), e);
       throw e;
@@ -116,46 +97,5 @@ public class FolioTenantService extends TenantService {
         getSchemaName()
       )
     );
-  }
-
-  private void createOriginalTenantIdCustomField() {
-    systemUserScopedExecutionService.executeSystemUserScoped(() -> {
-      if (ObjectUtils.isNotEmpty(customFieldService.getCustomFieldByName(ORIGINAL_TENANT_ID_NAME))) {
-        log.info("createOriginalTenantIdCustomField:: custom-field already available in tenant {} with name {}",
-          folioExecutionContext.getTenantId(), ORIGINAL_TENANT_ID_NAME);
-      } else {
-        createCustomFieldsWithRetry();
-      }
-      return null;
-    }
-    );
-  }
-
-  private void createCustomFieldsWithRetry() {
-    var retryTemplate = new RetryTemplate();
-
-    var fixedBackOffPolicy = new FixedBackOffPolicy();
-    fixedBackOffPolicy.setBackOffPeriod(customFieldsRetryProperties.getBackoffDelay());
-    retryTemplate.setBackOffPolicy(fixedBackOffPolicy);
-
-    var retryPolicy = new SimpleRetryPolicy();
-    retryPolicy.setMaxAttempts(customFieldsRetryProperties.getMaxAttempts());
-    retryTemplate.setRetryPolicy(retryPolicy);
-
-    retryTemplate.execute(arg -> createCustomField(), this::handleCustomFieldCreation);
-  }
-
-  private Object createCustomField() {
-    customFieldService.createCustomField(ORIGINAL_TENANT_ID_CUSTOM_FIELD);
-    return null;
-  }
-
-  private Object handleCustomFieldCreation(RetryContext arg) {
-    if (arg.getLastThrowable() != null) {
-      log.error("createCustomFieldsWithRetry:: Failed to create custom-field {} in tenant {}",
-        ORIGINAL_TENANT_ID_NAME, folioExecutionContext.getTenantId());
-      throw new CustomFieldCreationException(arg.getLastThrowable().getMessage());
-    }
-    return null;
   }
 }

--- a/src/main/java/org/folio/consortia/service/impl/CustomFieldServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/CustomFieldServiceImpl.java
@@ -7,6 +7,7 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.consortia.client.CustomFieldsClient;
 import org.folio.consortia.config.property.RelatedModulesProperties;
 import org.folio.consortia.domain.dto.CustomField;
+import org.folio.consortia.domain.dto.CustomFieldType;
 import org.folio.consortia.service.CustomFieldService;
 import org.springframework.stereotype.Service;
 
@@ -15,9 +16,17 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CustomFieldServiceImpl implements CustomFieldService {
 
-  private final CustomFieldsClient customFieldsClient;
-  private static final String QUERY_PATTERN_NAME = "name==%s";
+  public static final String ORIGINAL_TENANT_ID_NAME = "originalTenantId";
+  public static final CustomField ORIGINAL_TENANT_ID_CUSTOM_FIELD = CustomField.builder()
+    .name(ORIGINAL_TENANT_ID_NAME)
+    .entityType("user")
+    .helpText("Id of tenant where user created originally")
+    .customFieldType(CustomFieldType.TEXTBOX_LONG)
+    .visible(false)
+    .build();
 
+  private static final String QUERY_PATTERN_NAME = "name==%s";
+  private final CustomFieldsClient customFieldsClient;
   private final RelatedModulesProperties relatedModulesProperties;
 
   @Override

--- a/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantServiceImpl.java
@@ -1,5 +1,8 @@
 package org.folio.consortia.service.impl;
 
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
+import static org.folio.consortia.service.impl.CustomFieldServiceImpl.ORIGINAL_TENANT_ID_CUSTOM_FIELD;
+import static org.folio.consortia.service.impl.CustomFieldServiceImpl.ORIGINAL_TENANT_ID_NAME;
 import static org.folio.consortia.utils.Constants.SYSTEM_USER_NAME;
 import static org.folio.consortia.utils.HelperUtils.checkIdenticalOrThrow;
 
@@ -31,6 +34,7 @@ import org.folio.consortia.repository.TenantRepository;
 import org.folio.consortia.repository.UserTenantRepository;
 import org.folio.consortia.service.CleanupService;
 import org.folio.consortia.service.ConsortiumService;
+import org.folio.consortia.service.CustomFieldService;
 import org.folio.consortia.service.LockService;
 import org.folio.consortia.service.PermissionUserService;
 import org.folio.consortia.service.TenantService;
@@ -40,6 +44,7 @@ import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.context.ExecutionContextBuilder;
 import org.folio.spring.data.OffsetRequest;
 import org.folio.spring.scope.FolioExecutionContextSetter;
+import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -71,6 +76,8 @@ public class TenantServiceImpl implements TenantService {
   private final SyncPrimaryAffiliationClient syncPrimaryAffiliationClient;
   private final CleanupService cleanupService;
   private final LockService lockService;
+  private final SystemUserScopedExecutionService systemUserScopedExecutionService;
+  private final CustomFieldService customFieldService;
 
   @Override
   public TenantCollection get(UUID consortiumId, Integer offset, Integer limit) {
@@ -121,11 +128,26 @@ public class TenantServiceImpl implements TenantService {
     validateConsortiumAndTenantForSaveOperation(consortiumId, tenantDto);
     validateCodeAndNameUniqueness(tenantDto);
 
+    createCustomFieldIdNeeded(tenantDto.getId());
+
     var existingTenant = tenantRepository.findById(tenantDto.getId());
 
     // checked whether tenant exists or not.
     return existingTenant.isPresent() ? reAddSoftDeletedTenant(consortiumId, existingTenant.get(), tenantDto)
       : addNewTenant(consortiumId, tenantDto, adminUserId);
+  }
+
+  private void createCustomFieldIdNeeded(String tenant) {
+    systemUserScopedExecutionService.executeSystemUserScoped(tenant, () -> {
+        if (isNotEmpty(customFieldService.getCustomFieldByName(ORIGINAL_TENANT_ID_NAME))) {
+          log.info("createOriginalTenantIdCustomField:: custom-field already available in tenant {} with name {}",
+            tenant, ORIGINAL_TENANT_ID_NAME);
+        } else {
+          customFieldService.createCustomField(ORIGINAL_TENANT_ID_CUSTOM_FIELD);
+        }
+        return null;
+      }
+    );
   }
 
   private Tenant reAddSoftDeletedTenant(UUID consortiumId, TenantEntity existingTenant, Tenant tenantDto) {

--- a/src/test/java/org/folio/consortia/controller/FolioTenantControllerTest.java
+++ b/src/test/java/org/folio/consortia/controller/FolioTenantControllerTest.java
@@ -1,10 +1,6 @@
 package org.folio.consortia.controller;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -14,19 +10,13 @@ import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemp
 import com.github.tomakehurst.wiremock.extension.responsetemplating.TemplateEngine;
 import java.util.ArrayList;
 import org.folio.consortia.base.BaseIT;
-import org.folio.consortia.domain.dto.CustomField;
-import org.folio.consortia.service.CustomFieldService;
 import org.folio.tenant.domain.dto.TenantAttributes;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 class FolioTenantControllerTest extends BaseIT {
-
-  @MockBean
-  CustomFieldService customFieldService;
 
   @BeforeAll
   static void beforeAll(@Autowired MockMvc mockMvc) {
@@ -38,17 +28,6 @@ class FolioTenantControllerTest extends BaseIT {
           new ArrayList<>())));
 
     wireMockServer.start();
-  }
-
-  @Test
-  void enableTenant_negative_customFieldNotCreated() throws Exception {
-    when(customFieldService.getCustomFieldByName(anyString())).thenReturn(null);
-    doThrow(new RuntimeException("error")).when(customFieldService).createCustomField(any(CustomField.class));
-
-    mockMvc.perform(post("/_/tenant")
-        .headers(defaultHeaders())
-        .content(asJsonString(new TenantAttributes().moduleTo("mod-consortia-keycloak"))))
-      .andExpect(status().is(500));
   }
 
   @Test


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/MODCONSKC-32
Because we are trying to create a custom field during the module enablement stage, this operation requires a system user that is created asynchronously. Therefore, even if we create a custom field in mod-users with retries during module enablement, we cannot guarantee that the system user will exist in the system. As a result, we decided to move the creation of custom fields to an operation that is called during the consortium setup: save tenant /consortium/{consId}/tenant POST.

## Approach

- move custom field creation to save tenant operation
- add tests

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
