### PR TITLE
UICONSET-203. Hide sharing action button in case when not all permissions are presented

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -639,6 +639,28 @@
       "visible": true
     },
     {
+      "permissionName": "consortia.sharing-roles-all.item.post",
+      "displayName": "Consortia manager: Share roles",
+      "description": "Consortia manager: Share roles",
+      "subPermissions": [
+        "consortia.sharing-roles.item.post",
+        "consortia.sharing-roles-capability-sets.item.post",
+        "consortia.sharing-roles-capabilities.item.post"
+      ],
+      "visible": true
+    },
+    {
+      "permissionName": "consortia.sharing-roles-all.item.delete",
+      "displayName": "Consortia manager: Delete sharing roles",
+      "description": "Consortia manager: Delete sharing roles",
+      "subPermissions": [
+        "consortia.sharing-roles.item.delete",
+        "consortia.sharing-roles-capability-sets.item.delete",
+        "consortia.sharing-roles-capabilities.item.delete"
+      ],
+      "visible": true
+    },
+    {
       "permissionName": "consortia.sharing-instances.item.post",
       "displayName": "create sharing instance",
       "description": "Create sharing instance"


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/UICONSET-203

## Approach
Make to 2 permiision sets, for share roles and for delete sharing roles and make them visible, so they will be presented on UI but only when ECS mode is enabled, because mod-consortia-keycloak is enabled only on ECS mode