### PR TITLE
EUREKASUP-8: fix tenant data migration order to migrate user_tenant

### DIFF
--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -16,4 +16,5 @@
   <include file="changes/create-sharing-policy-table.xml" relativeToChangelogFile="true"/>
   <include file="changes/create-sharing-role-table.xml" relativeToChangelogFile="true"/>
   <include file="changes/migrate-tenant-data-from-mod-consortia.xml" relativeToChangelogFile="true"/>
+  <include file="changes/migrate-user-tenant-data-from-mod-consortia.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/migrate-data-from-mod-consortia.xml
+++ b/src/main/resources/db/changelog/changes/migrate-data-from-mod-consortia.xml
@@ -157,6 +157,9 @@
   </changeSet>
 
   <changeSet id="EUREKA-65@@migrate-data-from-mod_consortia.user_tenant" author="yaroslavkiriak">
+    <preConditions onFail="MARK_RAN">
+      <sqlCheck expectedResult="1">SELECT 0</sqlCheck>
+    </preConditions>
     <sql>
       DO
       '

--- a/src/main/resources/db/changelog/changes/migrate-user-tenant-data-from-mod-consortia.xml
+++ b/src/main/resources/db/changelog/changes/migrate-user-tenant-data-from-mod-consortia.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.17.xsd">
+
+  <changeSet id="MODCONSKC-40@@migrate-user-tenant-data-from-mod_consortia" author="yaroslavkiriak">
+    <sql>
+      DO
+      '
+      DECLARE
+      BEGIN
+        IF (EXISTS (SELECT 1 FROM information_schema.tables
+          WHERE table_schema = ''${tenantname}_mod_consortia'' AND table_name = ''user_tenant''))
+        THEN
+          INSERT INTO ${tenantname}_mod_consortia_keycloak.user_tenant (
+            id, user_id, username, tenant_id, is_primary, created_by, created_date, updated_by, updated_date
+          ) SELECT
+            id, user_id, username, tenant_id, is_primary, created_by, created_date, updated_by,
+            (CASE WHEN updated_date IS NULL THEN created_date ELSE updated_date END) as updated_date
+          FROM ${tenantname}_mod_consortia.user_tenant;
+        END IF;
+      END;
+      '  LANGUAGE plpgsql;
+    </sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/test/java/org/folio/consortia/repository/ConsortiaMigrationTest.java
+++ b/src/test/java/org/folio/consortia/repository/ConsortiaMigrationTest.java
@@ -89,7 +89,12 @@ class ConsortiaMigrationTest {
     var tenantIds = jdbcTemplate.queryForList(
       format("SELECT id FROM %s.%s", TENANT + "_mod_consortia_keycloak", "tenant"), String.class);
     assertThat(tenantIds).hasSize(1);
-    assertThat(ids.iterator().next()).isEqualTo("e2628d7d-059a-46a1-a5ea-10a5a37b1af2");
+    assertThat(tenantIds.iterator().next()).isEqualTo("e2628d7d-059a-46a1-a5ea-10a5a37b1af2");
+
+    var userTenantIds = jdbcTemplate.queryForList(
+      format("SELECT id FROM %s.%s", TENANT + "_mod_consortia_keycloak", "user_tenant"), String.class);
+    assertThat(userTenantIds).hasSize(1);
+    assertThat(userTenantIds.iterator().next()).isEqualTo("6ad28dae-7c02-4f89-9320-153c55bf1941");
   }
 
   @AfterAll

--- a/src/test/resources/sql/consortia_data.sql
+++ b/src/test/resources/sql/consortia_data.sql
@@ -40,3 +40,17 @@ CREATE TABLE consortium_mod_consortia.tenant (
 );
 INSERT INTO consortium_mod_consortia.tenant (id, name, consortium_id, code, is_central, setup_status, is_deleted)
 VALUES ('e2628d7d-059a-46a1-a5ea-10a5a37b1af2', 'name', '88888888-8888-4888-8888-888888888888', 'code', false, 'IN_PROGRESS', false);
+
+CREATE TABLE consortium_mod_consortia.user_tenant (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL,
+  username text NOT NULL,
+  tenant_id text NOT NULL,
+  is_primary boolean NOT NULL DEFAULT false,
+  created_by UUID,
+  created_date TIMESTAMP WITHOUT TIME ZONE DEFAULT now() NOT NULL,
+  updated_by UUID,
+  updated_date TIMESTAMP WITHOUT TIME ZONE
+);
+INSERT INTO consortium_mod_consortia.user_tenant (id, user_id, username, tenant_id)
+VALUES ('6ad28dae-7c02-4f89-9320-153c55bf1941', '6ad28dae-7c02-4f89-9320-153c55bf1914', 'name', 'e2628d7d-059a-46a1-a5ea-10a5a37b1af2');


### PR DESCRIPTION
## Purpose
Fix `tenant` data migration order to migrate `user_tenant`.
US: [EUREKASUP-8](https://folio-org.atlassian.net/browse/EUREKASUP-8)
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant Rally issue, add a link directly to the issue URL here.
 -->

## Approach
Reorder changesets to migrate `user_tenant` after `tenant` data because `user_tenant` depends on `tenant`.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
## Testing

<img width="1491" alt="image" src="https://github.com/user-attachments/assets/e6690970-4fae-4cb3-a20c-ba0ceedfdbc2">

<img width="1636" alt="image" src="https://github.com/user-attachments/assets/2081bb0f-169c-48fd-b38b-be84fdf18f65">


## TODOS and Open Questions

<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

- [ ] Check logging

## Learning

<!-- OPTIONAL
  Help out not only your reviewer but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries, or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:

Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added, or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do Rally stories exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail? Which endpoints/schemas changed, etc.
  - [ ] Do they have all the appropriate links to blocked/related issues?
- Are the Rally stories under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally, all the PRs involved in breaking changes would be merged on the same day to avoid breaking the folio-testing
environment. Communication is paramount if that is to be achieved, especially as the number of inter-module and
inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the
responsibility of the PR assignee.
