### PR TITLE
MODCONSKC-46. Up snasphot version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <groupId>org.folio</groupId>
   <artifactId>mod-consortia-keycloak</artifactId>
   <name>mod-consortia-keycloak</name>
-  <version>1.5.1-SNAPSHOT</version>
+  <version>1.6.0-SNAPSHOT</version>
   <description>Business logic to manage consortia in FOLIO</description>
   <packaging>jar</packaging>
 


### PR DESCRIPTION
## Purpose

The latest Q release is 1.5.1 and R release will be 1.6.0, so snapshot version should be changed accordinly
