### PR TITLE
MODCON-169 User with "Share" permission cannot share "Local" MARC bib record from member tenant

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -310,7 +310,7 @@
             "change-manager.jobExecutions.item.get",
             "change-manager.jobExecutions.children.collection.get",
             "change-manager.jobexecutions.post",
-            "change-manager.jobExecutions.item.put",
+            "change-manager.jobExecutions.jobProfile.item.put",
             "change-manager.records.post",
             "instance-authority-links.instances.collection.get",
             "instance-authority-links.instances.collection.put",


### PR DESCRIPTION
## Purpose
[MODCON-169](https://folio-org.atlassian.net/browse/MODCON-169) User with "Share" permission cannot share "Local" MARC bib record from member tenant

