### PR TITLE
MODCONSKC-58. Remove unnecessary validation for checking primary affiliation for system user

### DIFF
--- a/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
@@ -1,6 +1,5 @@
 package org.folio.consortia.service.impl;
 
-import static org.folio.consortia.utils.Constants.SYSTEM_USER_NAME;
 import static org.folio.spring.scope.FolioExecutionScopeExecutionContextManager.getRunnableWithCurrentFolioContext;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -284,10 +283,7 @@ public class PublicationServiceImpl implements PublicationService {
 
     // condition to support eureka system user approach
     if (context.getUserId() == null) {
-      var userExists = userTenantService.userHasPrimaryAffiliationByUsernameAndTenantId(SYSTEM_USER_NAME, context.getTenantId());
-      if (!userExists) {
-        throw new PublicationException(PublicationException.PRIMARY_AFFILIATION_NOT_EXISTS);
-      }
+      log.info("validatePublicationRequest:: skipping validating primary user affiliation for system user");
       return;
     }
 

--- a/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
@@ -275,7 +275,7 @@ public class PublicationServiceImpl implements PublicationService {
     log.info("updatePublicationsStatus:: updated publication record {} with status {}", publicationStatusEntity.getId(), publicationStatusEntity.getStatus());
   }
 
-  private void validatePublicationRequest(UUID consortiumId, PublicationRequest publication, FolioExecutionContext context) {
+  protected void validatePublicationRequest(UUID consortiumId, PublicationRequest publication, FolioExecutionContext context) {
     if (CollectionUtils.isEmpty(publication.getTenants())) {
       throw new PublicationException(PublicationException.TENANT_LIST_EMPTY);
     }

--- a/src/main/java/org/folio/consortia/utils/Constants.java
+++ b/src/main/java/org/folio/consortia/utils/Constants.java
@@ -1,9 +1,0 @@
-package org.folio.consortia.utils;
-
-public class Constants {
-
-  private Constants() {
-  }
-
-  public static final String SYSTEM_USER_NAME = "mod-consortia-keycloak";
-}

--- a/src/test/java/org/folio/consortia/controller/TenantControllerTest.java
+++ b/src/test/java/org/folio/consortia/controller/TenantControllerTest.java
@@ -6,7 +6,6 @@ import static org.folio.consortia.support.EntityUtils.createTenantDetailsEntity;
 import static org.folio.consortia.support.EntityUtils.createTenantEntity;
 import static org.folio.consortia.support.EntityUtils.createUser;
 import static org.folio.consortia.support.EntityUtils.createUserTenantEntity;
-import static org.folio.consortia.utils.Constants.SYSTEM_USER_NAME;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -152,14 +151,14 @@ class TenantControllerTest extends BaseIT {
     var headers = defaultHeaders();
     TenantEntity centralTenant = createTenantEntity(CENTRAL_TENANT_ID, CENTRAL_TENANT_ID, "AAA", true);
     User adminUser = createUser("diku_admin");
-    User systemUser = createUser(SYSTEM_USER_NAME);
+    User systemUser = createUser("mod-consortia-keycloak");
 
     var tenantDetailsEntity = new TenantDetailsEntity();
     tenantDetailsEntity.setConsortiumId(centralTenant.getConsortiumId());
     tenantDetailsEntity.setId("diku1234");
 
     doNothing().when(userTenantsClient).postUserTenant(any());
-    when(userService.getByUsername(SYSTEM_USER_NAME)).thenReturn(Optional.of(systemUser));
+    when(userService.getByUsername("mod-consortia-keycloak")).thenReturn(Optional.of(systemUser));
     when(userService.prepareShadowUser(UUID.fromString(adminUser.getId()), TENANT)).thenReturn(adminUser);
     when(userService.prepareShadowUser(UUID.fromString(systemUser.getId()), TENANT)).thenReturn(systemUser);
     when(userService.getById(any())).thenReturn(adminUser);


### PR DESCRIPTION
## Purpose
Continuation of https://folio-org.atlassian.net/browse/MODCONSKC-58
In Eureka system user can be used without checking primary affiliation, so this validation should be removed