### PR TITLE
MODCONSKC-60. Fix issue with adding consortia-configuration in member tenants

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -229,6 +229,7 @@
             "consortia.tenants.item.post"
           ],
           "modulePermissions": [
+            "consortia.consortia-configuration.item.post",
             "perms.users.item.put",
             "perms.users.item.post",
             "perms.users.assign.immutable",

--- a/src/main/java/org/folio/consortia/client/ConsortiaConfigurationClient.java
+++ b/src/main/java/org/folio/consortia/client/ConsortiaConfigurationClient.java
@@ -1,0 +1,15 @@
+package org.folio.consortia.client;
+
+import org.folio.consortia.domain.dto.ConsortiaConfiguration;
+import org.folio.spring.config.FeignClientConfiguration;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "consortia-configuration" , configuration = FeignClientConfiguration.class)
+public interface ConsortiaConfigurationClient {
+
+  @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+  void saveConfiguration(@RequestBody ConsortiaConfiguration configuration);
+}

--- a/src/main/java/org/folio/consortia/service/ConsortiaConfigurationService.java
+++ b/src/main/java/org/folio/consortia/service/ConsortiaConfigurationService.java
@@ -22,19 +22,10 @@ public interface ConsortiaConfigurationService {
 
   /**
    * Save new configuration with central tenant id as value.
-   * This configuration will be stored in requested tenant schema
-   *
-   * @param centralTenantId id of central tenant for requested tenant
-   * @throws ResourceAlreadyExistException if configuration already exists
-   */
-  ConsortiaConfiguration createConfiguration(String centralTenantId) throws ResourceAlreadyExistException;
-
-  /**
-   * Check if there exists a central tenant configuration;
-   * if not then save new configuration with central tenant id as value.
-   * This configuration will be stored in requested tenant schema
+   * This configuration will be stored in requested tenant schema.
+   * Will override configuration if already exists.
    *
    * @param centralTenantId id of central tenant for requested tenant
    */
-  void createConfigurationIfNeeded(String centralTenantId);
+  ConsortiaConfiguration createConfiguration(String centralTenantId);
 }

--- a/src/main/java/org/folio/consortia/service/impl/ConsortiaConfigurationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/ConsortiaConfigurationServiceImpl.java
@@ -1,13 +1,11 @@
 package org.folio.consortia.service.impl;
 
 import java.util.List;
-import java.util.function.Supplier;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.consortia.domain.dto.ConsortiaConfiguration;
 import org.folio.consortia.domain.entity.ConsortiaConfigurationEntity;
-import org.folio.consortia.exception.ResourceAlreadyExistException;
 import org.folio.consortia.exception.ResourceNotFoundException;
 import org.folio.consortia.repository.ConsortiaConfigurationRepository;
 import org.folio.consortia.service.ConsortiaConfigurationService;
@@ -20,8 +18,6 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class ConsortiaConfigurationServiceImpl implements ConsortiaConfigurationService {
-  private static final String CONSORTIA_CONFIGURATION_EXIST_MSG_TEMPLATE =
-    "System can not have more than one configuration record";
   private final ConsortiaConfigurationRepository configurationRepository;
   private final ConversionService converter;
   private final FolioExecutionContext folioExecutionContext;
@@ -39,21 +35,9 @@ public class ConsortiaConfigurationServiceImpl implements ConsortiaConfiguration
   }
 
   @Override
-  public ConsortiaConfiguration createConfiguration(String centralTenantId) throws ResourceAlreadyExistException {
-    return createConfiguration(centralTenantId, () -> {
-      throw new ResourceAlreadyExistException(CONSORTIA_CONFIGURATION_EXIST_MSG_TEMPLATE);
-    });
-  }
-
-  @Override
-  public void createConfigurationIfNeeded(String centralTenantId) {
-    createConfiguration(centralTenantId, this::getConsortiaConfiguration);
-  }
-
-  private ConsortiaConfiguration createConfiguration(String centralTenantId, Supplier<ConsortiaConfiguration> supplierIfConfigExists) {
+  public ConsortiaConfiguration createConfiguration(String centralTenantId) {
     if (configurationRepository.count() > 0) {
-      log.info("createConfiguration:: Configuration already exists for central tenant: '{}'", centralTenantId);
-      return supplierIfConfigExists.get();
+      log.info("createConfiguration:: Override existing consortia configuration with centralTenantId: '{}'", centralTenantId);
     }
     ConsortiaConfigurationEntity configuration = new ConsortiaConfigurationEntity();
     configuration.setCentralTenantId(centralTenantId);

--- a/src/test/java/org/folio/consortia/controller/TenantControllerTest.java
+++ b/src/test/java/org/folio/consortia/controller/TenantControllerTest.java
@@ -1,6 +1,5 @@
 package org.folio.consortia.controller;
 
-import static org.folio.consortia.support.EntityUtils.createConsortiaConfiguration;
 import static org.folio.consortia.support.EntityUtils.createTenant;
 import static org.folio.consortia.support.EntityUtils.createTenantDetailsEntity;
 import static org.folio.consortia.support.EntityUtils.createTenantEntity;
@@ -34,6 +33,7 @@ import java.util.Set;
 import java.util.UUID;
 import org.folio.consortia.base.BaseIT;
 import org.folio.consortia.client.CapabilitySetsClient;
+import org.folio.consortia.client.ConsortiaConfigurationClient;
 import org.folio.consortia.client.UserCapabilitySetsClient;
 import org.folio.consortia.client.UserTenantsClient;
 import org.folio.consortia.client.UsersClient;
@@ -54,7 +54,6 @@ import org.folio.consortia.repository.ConsortiumRepository;
 import org.folio.consortia.repository.TenantDetailsRepository;
 import org.folio.consortia.repository.TenantRepository;
 import org.folio.consortia.repository.UserTenantRepository;
-import org.folio.consortia.service.ConsortiaConfigurationService;
 import org.folio.consortia.service.SyncPrimaryAffiliationService;
 import org.folio.consortia.service.TenantService;
 import org.folio.consortia.service.UserService;
@@ -96,7 +95,7 @@ class TenantControllerTest extends BaseIT {
   @MockBean
   UserTenantRepository userTenantRepository;
   @MockBean
-  ConsortiaConfigurationService configurationService;
+  ConsortiaConfigurationClient consortiaConfigurationClient;
   @MockBean
   KafkaService kafkaService;
   @MockBean
@@ -169,7 +168,7 @@ class TenantControllerTest extends BaseIT {
     when(tenantDetailsRepository.save(any(TenantDetailsEntity.class))).thenReturn(tenantDetailsEntity);
     when(tenantRepository.findCentralTenant()).thenReturn(Optional.of(centralTenant));
     doNothing().when(syncPrimaryAffiliationService).syncPrimaryAffiliations(any(UUID.class), anyString(), anyString());
-    when(configurationService.createConfiguration(CENTRAL_TENANT_ID)).thenReturn(createConsortiaConfiguration(CENTRAL_TENANT_ID));
+    doNothing().when(consortiaConfigurationClient).saveConfiguration(any());
 
     this.mockMvc.perform(
         post("/consortia/7698e46-c3e3-11ed-afa1-0242ac120002/tenants?adminUserId=" + adminUser.getId())
@@ -272,7 +271,7 @@ class TenantControllerTest extends BaseIT {
 
     doReturn(new User()).when(usersKeycloakClient).getUsersByUserId(any());
     when(tenantRepository.findCentralTenant()).thenReturn(Optional.of(centralTenant));
-    when(configurationService.createConfiguration(CENTRAL_TENANT_ID)).thenReturn(createConsortiaConfiguration(CENTRAL_TENANT_ID));
+    doNothing().when(consortiaConfigurationClient).saveConfiguration(any());
 
     this.mockMvc.perform(post("/consortia/7698e46-c3e3-11ed-afa1-0242ac120002/tenants?adminUserId=111841e3-e6fb-4191-9fd8-5674a5107c34")
         .headers(headers).content(contentString))
@@ -311,7 +310,7 @@ class TenantControllerTest extends BaseIT {
     when(consortiumRepository.existsById(consortiumId)).thenReturn(true);
     when(tenantRepository.existsById(any(String.class))).thenReturn(false);
     when(tenantRepository.findCentralTenant()).thenReturn(Optional.of(centralTenant));
-    when(configurationService.createConfiguration(CENTRAL_TENANT_ID)).thenReturn(createConsortiaConfiguration(CENTRAL_TENANT_ID));
+    doNothing().when(consortiaConfigurationClient).saveConfiguration(any());
 
     Set<ConstraintViolation<?>> constraintViolations = new HashSet<>();
     constraintViolations.add(mock(ConstraintViolation.class));


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODCONSKC-56
After additional investigation it was observed that we can not use DB calls in another DB schemas without self invocations, because we could not change tenantId in runtime for creating SQL connection because SQL connection is gathered from the connection pool.
So SQL connection was created before we switch execution context:
![image](https://github.com/user-attachments/assets/4da6da08-d539-43a3-8b3f-a5e5402c3c8c)

As a solution we are back to using self invocation calls for this particular method.