### PR TITLE
[MODCONSKC-63] Create an identity provider in keycloak when adding a tenant to the consortia

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,19 +86,64 @@ requires and provides, the permissions, and the additional module metadata.
 
 ### Environment variables
 
-| Name                              |     Default value     | Description                                                                                                                                                |
-|:----------------------------------|:---------------------:|:-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| DB_HOST                           |       postgres        | Postgres hostname                                                                                                                                          |
-| DB_PORT                           |         5432          | Postgres port                                                                                                                                              |
-| DB_USERNAME                       |      folio_admin      | Postgres username                                                                                                                                          |
-| DB_PASSWORD                       |           -           | Postgres username password                                                                                                                                 |
-| DB_DATABASE                       |     okapi_modules     | Postgres database name                                                                                                                                     |
-| KAFKA_HOST                        |         kafka         | Kafka broker hostname                                                                                                                                      |
-| KAFKA_PORT                        |         9092          | Kafka broker port                                                                                                                                          |
-| KAFKA_SECURITY_PROTOCOL           |       PLAINTEXT       | Kafka security protocol used to communicate with brokers (SSL or PLAINTEXT)                                                                                |
-| KAFKA_SSL_KEYSTORE_LOCATION       |           -           | The location of the Kafka key store file. This is optional for client and can be used for two-way authentication for client.                               |
-| KAFKA_SSL_KEYSTORE_PASSWORD       |           -           | The store password for the Kafka key store file. This is optional for client and only needed if 'ssl.keystore.location' is configured.                     |
-| KAFKA_SSL_TRUSTSTORE_LOCATION     |           -           | The location of the Kafka trust store file.                                                                                                                |
-| KAFKA_SSL_TRUSTSTORE_PASSWORD     |           -           | The password for the Kafka trust store file. If a password is not set, trust store file configured will still be used, but integrity checking is disabled. |
-| ENV                               |         folio         | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed     |
-| OKAPI_URL                         |  http://sidecar:8081  | Okapi url                                                                                                                                                  | |
+| Name                          | Default value       | Description                                                                                                                                                |
+|:------------------------------|:--------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| DB_HOST                       | postgres            | Postgres hostname                                                                                                                                          |
+| DB_PORT                       | 5432                | Postgres port                                                                                                                                              |
+| DB_USERNAME                   | folio_admin         | Postgres username                                                                                                                                          |
+| DB_PASSWORD                   | -                   | Postgres username password                                                                                                                                 |
+| DB_DATABASE                   | okapi_modules       | Postgres database name                                                                                                                                     |
+| KAFKA_HOST                    | kafka               | Kafka broker hostname                                                                                                                                      |
+| KAFKA_PORT                    | 9092                | Kafka broker port                                                                                                                                          |
+| KAFKA_SECURITY_PROTOCOL       | PLAINTEXT           | Kafka security protocol used to communicate with brokers (SSL or PLAINTEXT)                                                                                |
+| KAFKA_SSL_KEYSTORE_LOCATION   | -                   | The location of the Kafka key store file. This is optional for client and can be used for two-way authentication for client.                               |
+| KAFKA_SSL_KEYSTORE_PASSWORD   | -                   | The store password for the Kafka key store file. This is optional for client and only needed if 'ssl.keystore.location' is configured.                     |
+| KAFKA_SSL_TRUSTSTORE_LOCATION | -                   | The location of the Kafka trust store file.                                                                                                                |
+| KAFKA_SSL_TRUSTSTORE_PASSWORD | -                   | The password for the Kafka trust store file. If a password is not set, trust store file configured will still be used, but integrity checking is disabled. |
+| ENV                           | folio               | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed     |
+| OKAPI_URL                     | http://sidecar:8081 | Okapi url                                                                                                                                                  |
+| SECRET_STORE_TYPE             | EPHEMERAL           | Defines the type of secret store to use.                                                                                                                   |
+
+### Keycloak environment variables
+
+| Name                                | Default value              | Description                                                       |
+|:------------------------------------|:---------------------------|:------------------------------------------------------------------|
+| KC_URL                              |                            | Keycloak URL used to perform HTTP requests by `KeycloakClient`.   |
+| KC_ADMIN_CLIENT_ID                  | folio-backend-admin-client | Keycloak client id                                                |
+| KC_ADMIN_GRANT_TYPE                 | client_credentials         | Defines grant type for issuing Keycloak token                     |
+| KC_CLIENT_TLS_ENABLED               | false                      | Enables TLS for keycloak clients.                                 |
+| KC_CLIENT_TLS_TRUSTSTORE_PATH       | -                          | Truststore file path for keycloak clients.                        |
+| KC_CLIENT_TLS_TRUSTSTORE_PASSWORD   | -                          | Truststore password for keycloak clients.                         |
+| KC_CLIENT_TLS_TRUSTSTORE_TYPE       | -                          | Truststore file type for keycloak clients.                        |
+| KC_LOGIN_CLIENT_SUFFIX              | -login-application         | Suffix of a Keycloak client who owns the authorization resources. |
+| SINGLE_TENANT_UX                    | false                      | Flag to enable single login UX with identity providers.           |
+| KC_IDENTITY_PROVIDER_BASE_URL       | -                          | Base URL to set up identity provider URLs with.                   |
+| KC_IDENTITY_PROVIDER_SUFFIX         | -                          | Identity provider alias suffix.                                   |
+| KC_IDENTITY_PROVIDER_DISPLAY_SUFFIX | -                          | Identity provider display name suffix.                            |
+
+### Secure storage environment variables
+
+#### AWS-SSM
+
+Required when `SECRET_STORE_TYPE=AWS_SSM`
+
+| Name                                          | Default value | Description                                                                                                                                                    |
+|:----------------------------------------------|:--------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SECRET_STORE_AWS_SSM_REGION                   | -             | The AWS region to pass to the AWS SSM Client Builder. If not set, the AWS Default Region Provider Chain is used to determine which region to use.              |
+| SECRET_STORE_AWS_SSM_USE_IAM                  | true          | If true, will rely on the current IAM role for authorization instead of explicitly providing AWS credentials (access_key/secret_key)                           |
+| SECRET_STORE_AWS_SSM_ECS_CREDENTIALS_ENDPOINT | -             | The HTTP endpoint to use for retrieving AWS credentials. This is ignored if useIAM is true                                                                     |
+| SECRET_STORE_AWS_SSM_ECS_CREDENTIALS_PATH     | -             | The path component of the credentials endpoint URI. This value is appended to the credentials endpoint to form the URI from which credentials can be obtained. |
+
+#### Vault
+
+Required when `SECRET_STORE_STORE_TYPE=VAULT`
+
+| Name                                    | Default value | Description                                                                         |
+|:----------------------------------------|:--------------|:------------------------------------------------------------------------------------|
+| SECRET_STORE_VAULT_TOKEN                | -             | token for accessing vault, may be a root token                                      |
+| SECRET_STORE_VAULT_ADDRESS              | -             | the address of your vault                                                           |
+| SECRET_STORE_VAULT_ENABLE_SSL           | false         | whether or not to use SSL                                                           |
+| SECRET_STORE_VAULT_PEM_FILE_PATH        | -             | the path to an X.509 certificate in unencrypted PEM format, using UTF-8 encoding    |
+| SECRET_STORE_VAULT_KEYSTORE_PASSWORD    | -             | the password used to access the JKS keystore (optional)                             |
+| SECRET_STORE_VAULT_KEYSTORE_FILE_PATH   | -             | the path to a JKS keystore file containing a client cert and private key            |
+| SECRET_STORE_VAULT_TRUSTSTORE_FILE_PATH | -             | the path to a JKS truststore file containing Vault server certs that can be trusted |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 
 ### Description
-`mod-consortia-keycloak` an alternative implementation of `mod-consortia` intended to be used in conjunction with other keycloak modules (e.g. `mod-users-keycloak`, etc.).
+
+`mod-consortia-keycloak` an alternative implementation of `mod-consortia` intended to be used in conjunction with other
+keycloak modules (e.g. `mod-users-keycloak`, etc.).
 
 ## Table of Contents
 
@@ -28,25 +30,28 @@ APIs for Consortia module.
 
 Consortia API provides the following URLs:
 
-| Method | URL                                                     | Permissions                           | Description                                                     |
-|--------|---------------------------------------------------------|---------------------------------------|-----------------------------------------------------------------|
-| GET    | /consortia/{consortiumId}/tenants                       | consortia.tenants.collection.get      | Gets list of tenants based on consortiumId                      |
-| GET    | /consortia/{consortiumId}/user-tenants                  | consortia.user-tenants.collection.get | Gets list of user-tenants based on consortiumId                 |
-| GET    | /consortia/{consortiumId}/user-tenants/{associationId}  | consortia.user-tenants.item.get       | Gets single user-tenant based on consortiumId and associationId |
-| GET    | /consortia/{consortiumId}                               | consortia.consortium.item.get         | Gets single tenant based on consortiumId                        |
-| GET    | /consortia                                              | consortia.consortium.collection.get   | Gets list of consortia                                          |
-| POST   | /consortia                                              | consortia.consortium.item.post        | Inserts single consortium                                       |
-| POST   | /consortia/{consortiumId}/tenants                       | consortia.tenants.item.post           | Inserts a single tenant based on consortiumId                   |
-| PUT    | /consortia/{consortiumId}/tenants/{tenantId}            | consortia.tenants.item.put            | Update a single tenant name based on consortiumId and tenantId  |
-| PUT    | /consortia/{consortiumId}                               | consortia.consortium.item.put         | Update consortium name based on consortiumId                    |
+| Method | URL                                                    | Permissions                           | Description                                                     |
+|--------|--------------------------------------------------------|---------------------------------------|-----------------------------------------------------------------|
+| GET    | /consortia/{consortiumId}/tenants                      | consortia.tenants.collection.get      | Gets list of tenants based on consortiumId                      |
+| GET    | /consortia/{consortiumId}/user-tenants                 | consortia.user-tenants.collection.get | Gets list of user-tenants based on consortiumId                 |
+| GET    | /consortia/{consortiumId}/user-tenants/{associationId} | consortia.user-tenants.item.get       | Gets single user-tenant based on consortiumId and associationId |
+| GET    | /consortia/{consortiumId}                              | consortia.consortium.item.get         | Gets single tenant based on consortiumId                        |
+| GET    | /consortia                                             | consortia.consortium.collection.get   | Gets list of consortia                                          |
+| POST   | /consortia                                             | consortia.consortium.item.post        | Inserts single consortium                                       |
+| POST   | /consortia/{consortiumId}/tenants                      | consortia.tenants.item.post           | Inserts a single tenant based on consortiumId                   |
+| PUT    | /consortia/{consortiumId}/tenants/{tenantId}           | consortia.tenants.item.put            | Update a single tenant name based on consortiumId and tenantId  |
+| PUT    | /consortia/{consortiumId}                              | consortia.consortium.item.put         | Update consortium name based on consortiumId                    |
 
 More detail about mod-consortia
- - API can be found on api-guide.md: [API Docs](/docs/api-guide.md).
- - Schema architecture can be found on Consortia wiki-page: [mod-consortia schema and ER diagram](https://wiki.folio.org/display/DD/Defining+Tenant+Schema+For+Consortia).
+
+- API can be found on api-guide.md: [API Docs](/docs/api-guide.md).
+- Schema architecture can be found on Consortia
+  wiki-page: [mod-consortia schema and ER diagram](https://wiki.folio.org/display/DD/Defining+Tenant+Schema+For+Consortia).
 
 ## Permissions
 
 Institutional users should be granted the following permissions in order to use this Consortia API:
+
 ```shell
 consortia.all
 ```
@@ -56,6 +61,7 @@ consortia.all
 ### Compiling
 
 Compile with
+
 ```shell
 mvn clean install
 ```
@@ -118,8 +124,8 @@ requires and provides, the permissions, and the additional module metadata.
 | KC_LOGIN_CLIENT_SUFFIX              | -login-application         | Suffix of a Keycloak client who owns the authorization resources. |
 | SINGLE_TENANT_UX                    | false                      | Flag to enable single login UX with identity providers.           |
 | KC_IDENTITY_PROVIDER_BASE_URL       | -                          | Base URL to set up identity provider URLs with.                   |
-| KC_IDENTITY_PROVIDER_SUFFIX         | -                          | Identity provider alias suffix.                                   |
-| KC_IDENTITY_PROVIDER_DISPLAY_SUFFIX | -                          | Identity provider display name suffix.                            |
+| KC_IDENTITY_PROVIDER_SUFFIX         | -keycloak-oidc             | Identity provider alias suffix.                                   |
+| KC_IDENTITY_PROVIDER_DISPLAY_SUFFIX | Keycloak OIDC              | Identity provider display name suffix.                            |
 
 ### Secure storage environment variables
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -259,7 +259,7 @@
             "consortia.tenants.item.delete"
           ],
           "modulePermissions": [
-            "consortia.consortia-configuration.item.delete",
+            "consortia.consortia-configuration.item.delete"
           ]
         },
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -230,7 +230,6 @@
           ],
           "modulePermissions": [
             "consortia.consortia-configuration.item.post",
-            "consortia.identity-provider.item.post",
             "perms.users.item.put",
             "perms.users.item.post",
             "perms.users.assign.immutable",
@@ -261,7 +260,6 @@
           ],
           "modulePermissions": [
             "consortia.consortia-configuration.item.delete",
-            "consortia.identity-provider.item.delete"
           ]
         },
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -230,6 +230,7 @@
           ],
           "modulePermissions": [
             "consortia.consortia-configuration.item.post",
+            "consortia.identity-provider.item.post",
             "perms.users.item.put",
             "perms.users.item.post",
             "perms.users.assign.immutable",
@@ -259,7 +260,8 @@
             "consortia.tenants.item.delete"
           ],
           "modulePermissions": [
-            "consortia.consortia-configuration.item.delete"
+            "consortia.consortia-configuration.item.delete",
+            "consortia.identity-provider.item.delete"
           ]
         },
         {
@@ -300,6 +302,26 @@
           "pathPattern": "/consortia/{consortiumId}/tenants/{tenantId}/create-primary-affiliations",
           "permissionsRequired": [
             "consortia.create-primary-affiliations.item.post"
+          ],
+          "modulePermissions": []
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/consortia/{consortiumId}/tenants/{tenantId}/identity-provider",
+          "permissionsRequired": [
+            "consortia.identity-provider.item.post"
+          ],
+          "modulePermissions": []
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "pathPattern": "/consortia/{consortiumId}/tenants/{tenantId}/identity-provider",
+          "permissionsRequired": [
+            "consortia.identity-provider.item.delete"
           ],
           "modulePermissions": []
         },
@@ -631,6 +653,8 @@
         "consortia.inventory.update-ownership.item.post",
         "consortia.sync-primary-affiliations.item.post",
         "consortia.create-primary-affiliations.item.post",
+        "consortia.identity-provider.item.post",
+        "consortia.identity-provider.item.delete",
         "consortia.sharing-instances.item.post",
         "consortia.sharing-instances.item.get",
         "consortia.sharing-instances.collection.get",
@@ -684,6 +708,16 @@
       "permissionName": "consortia.create-primary-affiliations.item.post",
       "displayName": "create consortia primary affiliation",
       "description": "create consortia primary affiliation"
+    },
+    {
+      "permissionName": "consortia.identity-provider.item.post",
+      "displayName": "create identity provider",
+      "description": "Create identity provider"
+    },
+    {
+      "permissionName": "consortia.identity-provider.item.delete",
+      "displayName": "delete identity provider",
+      "description": "Delete identity provider"
     },
     {
       "permissionName": "consortia.publications.item.post",

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <folio-service-tools.version>4.1.1</folio-service-tools.version>
     <openapi-generator.version>7.9.0</openapi-generator.version>
     <mapstruct.version>1.6.3</mapstruct.version>
-    <applications-poc-tools.version>2.0.0</applications-poc-tools.version>
+    <applications-poc-tools.version>2.3.0-SNAPSHOT</applications-poc-tools.version>
     <commons-lang3.version>3.17.0</commons-lang3.version>
 
     <!-- test dependencies -->
@@ -104,6 +104,11 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-backend-common</artifactId>
+      <version>${applications-poc-tools.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-tls-utils</artifactId>
       <version>${applications-poc-tools.version}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,11 @@
       <version>${applications-poc-tools.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-secret-store-starter</artifactId>
+      <version>${applications-poc-tools.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
       <exclusions>

--- a/src/main/java/org/folio/consortia/client/KeycloakClient.java
+++ b/src/main/java/org/folio/consortia/client/KeycloakClient.java
@@ -25,24 +25,60 @@ import org.springframework.web.bind.annotation.RequestParam;
   configuration = KeycloakFeignClientConfig.class)
 public interface KeycloakClient {
 
+  /**
+   * Login with backend admin cli credentials to get authorization token in master realm
+   *
+   * @param loginRequest containing following properties: client_id, client_secret, grant_type
+   * @return KeycloakTokenResponse
+   */
   @PostMapping(value = "/realms/master/protocol/openid-connect/token", consumes = APPLICATION_FORM_URLENCODED_VALUE)
   KeycloakTokenResponse login(@RequestBody Map<String, ?> loginRequest);
 
+  /**
+   * Get client credentials for a given client id in a realm
+   *
+   * @param realm    the realm to get client credentials from
+   * @param clientId the login client id
+   * @param token    authorization token
+   * @return list of KeycloakClientCredentials (should contain only one element)
+   */
   @GetMapping(value = "/admin/realms/{realm}/clients", produces = APPLICATION_JSON_VALUE)
   List<KeycloakClientCredentials> getClientCredentials(@PathVariable("realm") String realm,
                                                        @RequestParam("clientId") String clientId,
                                                        @RequestHeader(AUTHORIZATION) String token);
 
+  /**
+   * Get identity provider by alias in a realm
+   *
+   * @param realm realm to get identity provider from
+   * @param alias alias of the identity provider
+   * @param token authorization token
+   * @return KeycloakIdentityProvider
+   */
   @GetMapping("/admin/realms/{realm}/identity-provider/instances/{alias}")
   KeycloakIdentityProvider getIdentityProvider(@PathVariable("realm") String realm,
                                                @PathVariable("alias") String alias,
                                                @RequestHeader(AUTHORIZATION) String token);
 
+  /**
+   * Delete identity provider by alias in a realm
+   *
+   * @param realm realm to delete identity provider from
+   * @param alias alias of the identity provider
+   * @param token authorization token
+   */
   @DeleteMapping("/admin/realms/{realm}/identity-provider/instances/{alias}")
   void deleteIdentityProvider(@PathVariable("realm") String realm,
                               @PathVariable("alias") String alias,
                               @RequestHeader(AUTHORIZATION) String token);
 
+  /**
+   * Create identity provider in a realm
+   *
+   * @param realm realm to create identity provider in
+   * @param identityProvider identity provider to create
+   * @param token authorization token
+   */
   @PostMapping("/admin/realms/{realm}/identity-provider/instances")
   void createIdentityProvider(@PathVariable("realm") String realm,
                               @RequestBody KeycloakIdentityProvider identityProvider,

--- a/src/main/java/org/folio/consortia/client/KeycloakClient.java
+++ b/src/main/java/org/folio/consortia/client/KeycloakClient.java
@@ -2,10 +2,13 @@ package org.folio.consortia.client;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+import java.util.List;
 import java.util.Map;
 
 import org.folio.consortia.config.keycloak.KeycloakFeignClientConfig;
+import org.folio.consortia.domain.dto.KeycloakClientCredentials;
 import org.folio.consortia.domain.dto.KeycloakIdentityProvider;
 import org.folio.consortia.domain.dto.KeycloakTokenResponse;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -15,6 +18,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "keycloak",
   url = "#{keycloakProperties.url}",
@@ -23,6 +27,11 @@ public interface KeycloakClient {
 
   @PostMapping(value = "/realms/master/protocol/openid-connect/token", consumes = APPLICATION_FORM_URLENCODED_VALUE)
   KeycloakTokenResponse login(@RequestBody Map<String, ?> loginRequest);
+
+  @GetMapping(value = "/admin/realms/{realm}/clients", produces = APPLICATION_JSON_VALUE)
+  List<KeycloakClientCredentials> getClientCredentials(@PathVariable("realm") String realm,
+                                                       @RequestParam("clientId") String clientId,
+                                                       @RequestHeader(AUTHORIZATION) String token);
 
   @GetMapping("/admin/realms/{realm}/identity-provider/instances/{alias}")
   KeycloakIdentityProvider getIdentityProvider(@PathVariable("realm") String realm,

--- a/src/main/java/org/folio/consortia/client/KeycloakClient.java
+++ b/src/main/java/org/folio/consortia/client/KeycloakClient.java
@@ -1,0 +1,26 @@
+package org.folio.consortia.client;
+
+import org.folio.consortia.config.keycloak.KeycloakFeignClientConfig;
+import org.folio.consortia.domain.dto.KeycloakIdentityProvider;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "keycloak",
+  url = "#{keycloakProperties.url}",
+  configuration = KeycloakFeignClientConfig.class)
+public interface KeycloakClient {
+
+  @GetMapping("/admin/realms/{realm}/identity-provider/instances/{alias}")
+  KeycloakIdentityProvider getIdentityProvider(@PathVariable("realm") String realm, @PathVariable("alias") String alias);
+
+  @DeleteMapping("/admin/realms/{realm}/identity-provider/instances/{alias}")
+  void deleteIdentityProvider(@PathVariable("realm") String realm, @PathVariable("alias") String alias);
+
+  @PostMapping("/admin/realms/{realm}/identity-provider/instances")
+  void createIdentityProvider(@PathVariable("realm") String realm, @RequestBody KeycloakIdentityProvider identityProvider);
+
+}

--- a/src/main/java/org/folio/consortia/client/KeycloakClient.java
+++ b/src/main/java/org/folio/consortia/client/KeycloakClient.java
@@ -1,26 +1,42 @@
 package org.folio.consortia.client;
 
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE;
+
+import java.util.Map;
+
 import org.folio.consortia.config.keycloak.KeycloakFeignClientConfig;
 import org.folio.consortia.domain.dto.KeycloakIdentityProvider;
+import org.folio.consortia.domain.dto.KeycloakTokenResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(name = "keycloak",
   url = "#{keycloakProperties.url}",
   configuration = KeycloakFeignClientConfig.class)
 public interface KeycloakClient {
 
+  @PostMapping(value = "/realms/master/protocol/openid-connect/token", consumes = APPLICATION_FORM_URLENCODED_VALUE)
+  KeycloakTokenResponse login(@RequestBody Map<String, ?> loginRequest);
+
   @GetMapping("/admin/realms/{realm}/identity-provider/instances/{alias}")
-  KeycloakIdentityProvider getIdentityProvider(@PathVariable("realm") String realm, @PathVariable("alias") String alias);
+  KeycloakIdentityProvider getIdentityProvider(@PathVariable("realm") String realm,
+                                               @PathVariable("alias") String alias,
+                                               @RequestHeader(AUTHORIZATION) String token);
 
   @DeleteMapping("/admin/realms/{realm}/identity-provider/instances/{alias}")
-  void deleteIdentityProvider(@PathVariable("realm") String realm, @PathVariable("alias") String alias);
+  void deleteIdentityProvider(@PathVariable("realm") String realm,
+                              @PathVariable("alias") String alias,
+                              @RequestHeader(AUTHORIZATION) String token);
 
   @PostMapping("/admin/realms/{realm}/identity-provider/instances")
-  void createIdentityProvider(@PathVariable("realm") String realm, @RequestBody KeycloakIdentityProvider identityProvider);
+  void createIdentityProvider(@PathVariable("realm") String realm,
+                              @RequestBody KeycloakIdentityProvider identityProvider,
+                              @RequestHeader(AUTHORIZATION) String token);
 
 }

--- a/src/main/java/org/folio/consortia/config/AppConfig.java
+++ b/src/main/java/org/folio/consortia/config/AppConfig.java
@@ -13,10 +13,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.format.FormatterRegistry;
-import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -42,16 +40,6 @@ public class AppConfig implements WebMvcConfigurer {
     executor.setThreadNamePrefix("ConsortiaAsync-");
     executor.initialize();
     return executor;
-  }
-
-  @Bean("asyncTaskScheduler")
-  public TaskScheduler asyncTaskScheduler() {
-    ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-    scheduler.setPoolSize(10);
-    scheduler.setWaitForTasksToCompleteOnShutdown(true);
-    scheduler.setThreadNamePrefix("ConsortiaAsyncScheduler-");
-    scheduler.initialize();
-    return scheduler;
   }
 
   @Primary

--- a/src/main/java/org/folio/consortia/config/AppConfig.java
+++ b/src/main/java/org/folio/consortia/config/AppConfig.java
@@ -13,8 +13,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -29,6 +31,7 @@ public class AppConfig implements WebMvcConfigurer {
     registry.addConverter(new UserTenantConverter());
     registry.addConverter(new ConsortiumConverter());
   }
+
   @Primary
   @Bean("asyncTaskExecutor")
   public TaskExecutor asyncTaskExecutor() {
@@ -39,6 +42,16 @@ public class AppConfig implements WebMvcConfigurer {
     executor.setThreadNamePrefix("ConsortiaAsync-");
     executor.initialize();
     return executor;
+  }
+
+  @Bean("asyncTaskScheduler")
+  public TaskScheduler asyncTaskScheduler() {
+    ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+    scheduler.setPoolSize(10);
+    scheduler.setWaitForTasksToCompleteOnShutdown(true);
+    scheduler.setThreadNamePrefix("ConsortiaAsyncScheduler-");
+    scheduler.initialize();
+    return scheduler;
   }
 
   @Primary

--- a/src/main/java/org/folio/consortia/config/keycloak/KeycloakFeignClientConfig.java
+++ b/src/main/java/org/folio/consortia/config/keycloak/KeycloakFeignClientConfig.java
@@ -1,0 +1,15 @@
+package org.folio.consortia.config.keycloak;
+
+import feign.Client;
+import lombok.extern.log4j.Log4j2;
+import org.folio.common.utils.tls.FeignClientTlsUtils;
+import org.springframework.context.annotation.Bean;
+
+@Log4j2
+public class KeycloakFeignClientConfig {
+
+  @Bean
+  public Client feignClient(KeycloakProperties properties, okhttp3.OkHttpClient okHttpClient) {
+    return FeignClientTlsUtils.getOkHttpClient(okHttpClient, properties.getTls());
+  }
+}

--- a/src/main/java/org/folio/consortia/config/keycloak/KeycloakFeignClientConfig.java
+++ b/src/main/java/org/folio/consortia/config/keycloak/KeycloakFeignClientConfig.java
@@ -7,7 +7,6 @@ import org.springframework.context.annotation.Bean;
 
 @Log4j2
 public class KeycloakFeignClientConfig {
-
   @Bean
   public Client feignClient(KeycloakProperties properties, okhttp3.OkHttpClient okHttpClient) {
     return FeignClientTlsUtils.getOkHttpClient(okHttpClient, properties.getTls());

--- a/src/main/java/org/folio/consortia/config/keycloak/KeycloakIdentityProviderProperties.java
+++ b/src/main/java/org/folio/consortia/config/keycloak/KeycloakIdentityProviderProperties.java
@@ -10,10 +10,10 @@ import lombok.Data;
 @Data
 @Component
 @Validated
-@ConfigurationProperties(prefix = "application.keycloak.identity-provider")
+@ConfigurationProperties(prefix = "folio.keycloak.identity-provider")
 public class KeycloakIdentityProviderProperties {
   @NotNull
-  private Boolean isEnabled;
+  private Boolean enabled;
   @NotNull
   private String alias;
   @NotNull

--- a/src/main/java/org/folio/consortia/config/keycloak/KeycloakIdentityProviderProperties.java
+++ b/src/main/java/org/folio/consortia/config/keycloak/KeycloakIdentityProviderProperties.java
@@ -10,7 +10,7 @@ import lombok.Data;
 @Data
 @Component
 @Validated
-@ConfigurationProperties(prefix = "folio.keycloak.identity-provider")
+@ConfigurationProperties(prefix = "application.keycloak.identity-provider")
 public class KeycloakIdentityProviderProperties {
   @NotNull
   private Boolean enabled;

--- a/src/main/java/org/folio/consortia/config/keycloak/KeycloakIdentityProviderProperties.java
+++ b/src/main/java/org/folio/consortia/config/keycloak/KeycloakIdentityProviderProperties.java
@@ -1,0 +1,25 @@
+package org.folio.consortia.config.keycloak;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+@Component
+@Validated
+@ConfigurationProperties(prefix = "application.keycloak.identity-provider")
+public class KeycloakIdentityProviderProperties {
+
+  @NotNull
+  private Boolean isEnabled;
+
+  @NotNull
+  private String alias;
+
+  @NotNull
+  private String displayName;
+
+}

--- a/src/main/java/org/folio/consortia/config/keycloak/KeycloakIdentityProviderProperties.java
+++ b/src/main/java/org/folio/consortia/config/keycloak/KeycloakIdentityProviderProperties.java
@@ -15,6 +15,8 @@ public class KeycloakIdentityProviderProperties {
   @NotNull
   private Boolean enabled;
   @NotNull
+  private String baseUrl;
+  @NotNull
   private String alias;
   @NotNull
   private String displayName;

--- a/src/main/java/org/folio/consortia/config/keycloak/KeycloakLoginClientProperties.java
+++ b/src/main/java/org/folio/consortia/config/keycloak/KeycloakLoginClientProperties.java
@@ -14,6 +14,4 @@ import lombok.Data;
 public class KeycloakLoginClientProperties {
   @NotNull
   private String clientNameSuffix;
-  @NotNull
-  private Boolean secureStoreDisabled;
 }

--- a/src/main/java/org/folio/consortia/config/keycloak/KeycloakLoginClientProperties.java
+++ b/src/main/java/org/folio/consortia/config/keycloak/KeycloakLoginClientProperties.java
@@ -10,12 +10,10 @@ import lombok.Data;
 @Data
 @Component
 @Validated
-@ConfigurationProperties(prefix = "application.keycloak.identity-provider")
-public class KeycloakIdentityProviderProperties {
+@ConfigurationProperties(prefix = "application.keycloak.login")
+public class KeycloakLoginClientProperties {
   @NotNull
-  private Boolean isEnabled;
+  private String clientNameSuffix;
   @NotNull
-  private String alias;
-  @NotNull
-  private String displayName;
+  private Boolean secureStoreDisabled;
 }

--- a/src/main/java/org/folio/consortia/config/keycloak/KeycloakLoginClientProperties.java
+++ b/src/main/java/org/folio/consortia/config/keycloak/KeycloakLoginClientProperties.java
@@ -10,7 +10,7 @@ import lombok.Data;
 @Data
 @Component
 @Validated
-@ConfigurationProperties(prefix = "application.keycloak.login")
+@ConfigurationProperties(prefix = "folio.keycloak.login")
 public class KeycloakLoginClientProperties {
   @NotNull
   private String clientNameSuffix;

--- a/src/main/java/org/folio/consortia/config/keycloak/KeycloakLoginClientProperties.java
+++ b/src/main/java/org/folio/consortia/config/keycloak/KeycloakLoginClientProperties.java
@@ -10,7 +10,7 @@ import lombok.Data;
 @Data
 @Component
 @Validated
-@ConfigurationProperties(prefix = "folio.keycloak.login")
+@ConfigurationProperties(prefix = "application.keycloak.login")
 public class KeycloakLoginClientProperties {
   @NotNull
   private String clientNameSuffix;

--- a/src/main/java/org/folio/consortia/config/keycloak/KeycloakProperties.java
+++ b/src/main/java/org/folio/consortia/config/keycloak/KeycloakProperties.java
@@ -11,7 +11,7 @@ import org.springframework.validation.annotation.Validated;
 @Data
 @Component
 @Validated
-@ConfigurationProperties(prefix = "folio.keycloak")
+@ConfigurationProperties(prefix = "application.keycloak")
 public class KeycloakProperties {
 
   @NotNull

--- a/src/main/java/org/folio/consortia/config/keycloak/KeycloakProperties.java
+++ b/src/main/java/org/folio/consortia/config/keycloak/KeycloakProperties.java
@@ -1,0 +1,25 @@
+package org.folio.consortia.config.keycloak;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import org.folio.common.configuration.properties.TlsProperties;
+import org.hibernate.validator.constraints.URL;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
+
+@Data
+@Component
+@Validated
+@ConfigurationProperties(prefix = "application.keycloak")
+public class KeycloakProperties {
+
+  @NotNull
+  private String grantType;
+  @NotNull
+  private String clientId;
+  @URL
+  private String url;
+  @NotNull
+  private TlsProperties tls;
+}

--- a/src/main/java/org/folio/consortia/config/keycloak/KeycloakProperties.java
+++ b/src/main/java/org/folio/consortia/config/keycloak/KeycloakProperties.java
@@ -11,7 +11,7 @@ import org.springframework.validation.annotation.Validated;
 @Data
 @Component
 @Validated
-@ConfigurationProperties(prefix = "application.keycloak")
+@ConfigurationProperties(prefix = "folio.keycloak")
 public class KeycloakProperties {
 
   @NotNull

--- a/src/main/java/org/folio/consortia/controller/TenantController.java
+++ b/src/main/java/org/folio/consortia/controller/TenantController.java
@@ -16,7 +16,6 @@ import org.folio.consortia.service.SyncPrimaryAffiliationService;
 import org.folio.consortia.service.TenantManager;
 import org.folio.consortia.service.TenantService;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -65,7 +64,7 @@ public class TenantController implements TenantsApi {
   public ResponseEntity<Void> syncPrimaryAffiliations(UUID consortiumId, String tenantId, @NotNull String centralTenantId) {
     try {
       syncPrimaryAffiliationService.syncPrimaryAffiliations(consortiumId, tenantId, centralTenantId);
-      return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+      return ResponseEntity.status(NO_CONTENT).build();
     } catch (Exception e) {
       log.error("syncPrimaryAffiliations:: error syncing user primary affiliations", e);
       tenantService.updateTenantSetupStatus(tenantId, centralTenantId, SetupStatusEnum.FAILED);
@@ -78,11 +77,24 @@ public class TenantController implements TenantsApi {
       SyncPrimaryAffiliationBody syncPrimaryAffiliationBody) {
     try {
       syncPrimaryAffiliationService.syncPrimaryUserAffiliations(consortiumId, centralTenantId, syncPrimaryAffiliationBody);
-      return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+      return ResponseEntity.status(NO_CONTENT).build();
     } catch (Exception e) {
       log.error("createPrimaryAffiliations:: error creating user primary affiliations", e);
       tenantService.updateTenantSetupStatus(tenantId, centralTenantId, SetupStatusEnum.FAILED);
       throw e;
     }
   }
+
+  @Override
+  public ResponseEntity<Void> createIdentityProvider(UUID consortiumId, String tenantId) {
+    tenantManager.createIdentityProvider(tenantId);
+    return ResponseEntity.status(CREATED).build();
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteIdentityProvider(UUID consortiumId, String tenantId) {
+    tenantManager.deleteIdentityProvider(tenantId);
+    return ResponseEntity.status(NO_CONTENT).build();
+  }
+
 }

--- a/src/main/java/org/folio/consortia/domain/dto/KeycloakClientCredentials.java
+++ b/src/main/java/org/folio/consortia/domain/dto/KeycloakClientCredentials.java
@@ -1,4 +1,25 @@
 package org.folio.consortia.domain.dto;
 
-public record KeycloakClientCredentials(String clientId, String clientSecret) {
+import java.io.Serial;
+import java.io.Serializable;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KeycloakClientCredentials implements Serializable {
+
+  @Serial
+  private static final long serialVersionUID = -5450019006221767712L;
+
+  private String id;
+  private String clientId;
+  private String secret;
+  private Boolean enabled;
+
 }

--- a/src/main/java/org/folio/consortia/domain/dto/KeycloakClientCredentials.java
+++ b/src/main/java/org/folio/consortia/domain/dto/KeycloakClientCredentials.java
@@ -1,0 +1,4 @@
+package org.folio.consortia.domain.dto;
+
+public record KeycloakClientCredentials(String clientId, String clientSecret) {
+}

--- a/src/main/java/org/folio/consortia/domain/dto/KeycloakIdentityProvider.java
+++ b/src/main/java/org/folio/consortia/domain/dto/KeycloakIdentityProvider.java
@@ -1,0 +1,43 @@
+package org.folio.consortia.domain.dto;
+
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+public class KeycloakIdentityProvider {
+
+  private String alias;
+  private String displayName;
+  private String providerId;
+  private boolean enabled;
+  private ClientConfig config;
+
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Data
+  @Builder
+  public static class ClientConfig {
+    private String clientId;
+    private String clientSecret;
+    private String clientAuthMethod;
+
+    private String authorizationUrl;
+    private String tokenUrl;
+    private String logoutUrl;
+    private String userInfoUrl;
+    private String issuer;
+    private String jwksUrl;
+
+    private boolean validateSignature;
+    private boolean useJwksUrl;
+    private boolean pkceEnabled;
+  }
+
+}

--- a/src/main/java/org/folio/consortia/domain/dto/KeycloakIdentityProvider.java
+++ b/src/main/java/org/folio/consortia/domain/dto/KeycloakIdentityProvider.java
@@ -16,7 +16,6 @@ public class KeycloakIdentityProvider {
   private String alias;
   private String displayName;
   private String providerId;
-  private boolean enabled;
   private ClientConfig config;
 
   @AllArgsConstructor

--- a/src/main/java/org/folio/consortia/domain/dto/KeycloakTokenResponse.java
+++ b/src/main/java/org/folio/consortia/domain/dto/KeycloakTokenResponse.java
@@ -1,0 +1,30 @@
+package org.folio.consortia.domain.dto;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+
+@Data
+public class KeycloakTokenResponse implements Serializable {
+
+  @Serial
+  private static final long serialVersionUID = -6851487096857200187L;
+
+  @JsonProperty("access_token")
+  private String accessToken;
+
+  @JsonProperty("expires_in")
+  private Long expiresIn;
+
+  @JsonProperty("refresh_expires_in")
+  private Long refreshExpiresIn;
+
+  @JsonProperty("refresh_token")
+  private String refreshToken;
+
+  @JsonProperty("token_type")
+  private String tokenType;
+}

--- a/src/main/java/org/folio/consortia/service/KeycloakCredentialsService.java
+++ b/src/main/java/org/folio/consortia/service/KeycloakCredentialsService.java
@@ -5,13 +5,13 @@ import org.folio.consortia.domain.dto.KeycloakClientCredentials;
 public interface KeycloakCredentialsService {
 
   /**
-   * Returns client id and secret for member tenant login client in central realm
+   * Returns client credentials for a login client of a tenant
    *
-   * @param centralTenant central tenant for getting correct realm
-   * @param memberTenant member tenant for getting correct client id
-   * @return Credentials for member tenant client in central realm
+   * @param tenantId tenant to fetch client credentials for
+   * @param token    authorization token for keycloak client
+   * @return Credentials for a tenant login client
    */
-  KeycloakClientCredentials getClientCredentials(String centralTenant, String memberTenant) ;
+  KeycloakClientCredentials getClientCredentials(String tenantId, String token) ;
 
   /**
    * Returns master realm admin token for Keycloak communication

--- a/src/main/java/org/folio/consortia/service/KeycloakCredentialsService.java
+++ b/src/main/java/org/folio/consortia/service/KeycloakCredentialsService.java
@@ -1,0 +1,28 @@
+package org.folio.consortia.service;
+
+import org.folio.consortia.domain.dto.KeycloakClientCredentials;
+
+public interface KeycloakCredentialsService {
+
+  /**
+   * Returns client id and secret for member tenant login client in central realm
+   *
+   * @param centralTenant central tenant for getting correct realm
+   * @param memberTenant member tenant for getting correct client id
+   * @return Credentials for member tenant client in central realm
+   */
+  KeycloakClientCredentials getClientCredentials(String centralTenant, String memberTenant) ;
+
+  /**
+   * Returns master realm admin token for Keycloak communication
+   *
+   * @return Master realm admin token
+   */
+  String getMasterAuthToken();
+
+  /**
+   * Evicts master realm admin token from cache
+   */
+  void evictMasterAuthToken();
+
+}

--- a/src/main/java/org/folio/consortia/service/KeycloakCredentialsService.java
+++ b/src/main/java/org/folio/consortia/service/KeycloakCredentialsService.java
@@ -20,9 +20,4 @@ public interface KeycloakCredentialsService {
    */
   String getMasterAuthToken();
 
-  /**
-   * Evicts master realm admin token from cache
-   */
-  void evictMasterAuthToken();
-
 }

--- a/src/main/java/org/folio/consortia/service/KeycloakService.java
+++ b/src/main/java/org/folio/consortia/service/KeycloakService.java
@@ -1,0 +1,25 @@
+package org.folio.consortia.service;
+
+public interface KeycloakService {
+
+  /**
+   * Creates an identity provider in the central tenant realm for the member tenant.
+   * In case the identity provider already exists, it will not be created again to
+   * support tenant removal and re-creation.
+   *
+   * @param centralTenant central tenant
+   * @param memberTenant  member tenant
+   * @param clientId     identity provider client id
+   * @param clientSecret identity provider client secret
+   */
+  void createIdentityProvider(String centralTenant, String memberTenant, String clientId, String clientSecret);
+
+  /**
+   * Deletes an identity provider in the central tenant realm corresponding to the member tenant.
+   *
+   * @param centralTenant central tenant
+   * @param memberTenant  member tenant
+   */
+  void deleteIdentityProvider(String centralTenant, String memberTenant);
+
+}

--- a/src/main/java/org/folio/consortia/service/KeycloakService.java
+++ b/src/main/java/org/folio/consortia/service/KeycloakService.java
@@ -3,9 +3,10 @@ package org.folio.consortia.service;
 public interface KeycloakService {
 
   /**
-   * Creates an identity provider in the central tenant realm for the member tenant.
-   * In case the identity provider already exists, it will not be created again to
-   * support tenant removal and re-creation.
+   * Creates an identity provider in the central tenant realm for the member tenant with conditions:<br/>
+   * 1) In case the identity provider already exists, it will not be created again to
+   * support tenant removal and re-creation.<br/>
+   * 2) If the identity provider creation is disabled, the method will return without any action
    *
    * @param centralTenant central tenant
    * @param memberTenant  member tenant
@@ -13,7 +14,8 @@ public interface KeycloakService {
   void createIdentityProvider(String centralTenant, String memberTenant);
 
   /**
-   * Deletes an identity provider in the central tenant realm corresponding to the member tenant.
+   * Deletes an identity provider in the central tenant realm corresponding to the member tenant.<br/>
+   * If the identity provider creation is disabled, the method will return without any action
    *
    * @param centralTenant central tenant
    * @param memberTenant  member tenant

--- a/src/main/java/org/folio/consortia/service/KeycloakService.java
+++ b/src/main/java/org/folio/consortia/service/KeycloakService.java
@@ -8,18 +8,18 @@ public interface KeycloakService {
    * support tenant removal and re-creation.<br/>
    * 2) If the identity provider creation is disabled, the method will return without any action
    *
-   * @param centralTenant central tenant
-   * @param memberTenant  member tenant
+   * @param centralTenantId central tenant
+   * @param memberTenantId  member tenant
    */
-  void createIdentityProvider(String centralTenant, String memberTenant);
+  void createIdentityProvider(String centralTenantId, String memberTenantId);
 
   /**
    * Deletes an identity provider in the central tenant realm corresponding to the member tenant.<br/>
    * If the identity provider creation is disabled, the method will return without any action
    *
-   * @param centralTenant central tenant
-   * @param memberTenant  member tenant
+   * @param centralTenantId central tenant
+   * @param memberTenantId  member tenant
    */
-  void deleteIdentityProvider(String centralTenant, String memberTenant);
+  void deleteIdentityProvider(String centralTenantId, String memberTenantId);
 
 }

--- a/src/main/java/org/folio/consortia/service/KeycloakService.java
+++ b/src/main/java/org/folio/consortia/service/KeycloakService.java
@@ -9,10 +9,8 @@ public interface KeycloakService {
    *
    * @param centralTenant central tenant
    * @param memberTenant  member tenant
-   * @param clientId     identity provider client id
-   * @param clientSecret identity provider client secret
    */
-  void createIdentityProvider(String centralTenant, String memberTenant, String clientId, String clientSecret);
+  void createIdentityProvider(String centralTenant, String memberTenant);
 
   /**
    * Deletes an identity provider in the central tenant realm corresponding to the member tenant.

--- a/src/main/java/org/folio/consortia/service/TenantManager.java
+++ b/src/main/java/org/folio/consortia/service/TenantManager.java
@@ -57,15 +57,15 @@ public interface TenantManager {
   /**
    * Creates an identity provider for the member tenant in the execution context tenant realm.
    *
-   * @param memberTenant the tenant to create the identity provider for
+   * @param memberTenantId the tenant to create the identity provider for
    */
-  void createIdentityProvider(String memberTenant);
+  void createIdentityProvider(String memberTenantId);
 
   /**
    * Deletes an identity provider of the member tenant from the execution context tenant realm.
    *
-   * @param memberTenant the tenant to delete the identity provider of
+   * @param memberTenantId the tenant to delete the identity provider of
    */
-  void deleteIdentityProvider(String memberTenant);
+  void deleteIdentityProvider(String memberTenantId);
 
 }

--- a/src/main/java/org/folio/consortia/service/TenantManager.java
+++ b/src/main/java/org/folio/consortia/service/TenantManager.java
@@ -53,4 +53,19 @@ public interface TenantManager {
    */
   void delete(UUID consortiumId, String tenantId, TenantDeleteRequest tenantDeleteRequest);
 
+
+  /**
+   * Creates an identity provider for the member tenant in the execution context tenant realm.
+   *
+   * @param memberTenant the tenant to create the identity provider for
+   */
+  void createIdentityProvider(String memberTenant);
+
+  /**
+   * Deletes an identity provider of the member tenant from the execution context tenant realm.
+   *
+   * @param memberTenant the tenant to delete the identity provider of
+   */
+  void deleteIdentityProvider(String memberTenant);
+
 }

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakCredentialsServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakCredentialsServiceImpl.java
@@ -52,7 +52,7 @@ public class KeycloakCredentialsServiceImpl implements KeycloakCredentialsServic
   @Cacheable(cacheNames = "keycloak-token", key = MASTER_TOKEN_CACHE_KEY)
   public String getMasterAuthToken() {
     var clientId = keycloakProperties.getClientId();
-    var clientSecret = retrieveKcClientSecret(MASTER_REALM, clientId);
+    var clientSecret = getBackendAdminClientSecret(clientId);
 
     HashMap<String, String> loginRequest = new HashMap<>();
     loginRequest.put("client_id", clientId);
@@ -76,16 +76,12 @@ public class KeycloakCredentialsServiceImpl implements KeycloakCredentialsServic
     log.info("evictMasterAuthToken:: Evicting master realm admin token from cache");
   }
 
-  private String retrieveKcClientSecret(String realm, String clientId) {
-    if (Boolean.TRUE.equals(keycloakClientProperties.getSecureStoreDisabled())) {
-      log.info("retrieveKcClientSecret:: Secure store is disabled. Using default client secret for clientId: {}", clientId);
-      return "SecretPassword";
-    }
+  private String getBackendAdminClientSecret(String clientId) {
     try {
-      log.info("retrieveKcClientSecret:: Retrieving client secret from secure store");
-      return secureStore.get("%s_%s_%s".formatted(folioEnvironment, realm, clientId));
+      log.info("getBackendAdminClientSecret:: Retrieving backend admin client secret from secure store");
+      return secureStore.get("%s_%s_%s".formatted(folioEnvironment, MASTER_REALM, clientId));
     } catch (NotFoundException e) {
-      log.error("retrieveKcClientSecret:: Client secret not found in secure store for clientId: {}", clientId);
+      log.error("getBackendAdminClientSecret:: Backend admin client secret not found in secure store for clientId: {}", clientId);
       throw new IllegalStateException("Failed to get value from secure store [clientId: %s]".formatted(clientId), e);
     }
   }

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakCredentialsServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakCredentialsServiceImpl.java
@@ -72,14 +72,14 @@ public class KeycloakCredentialsServiceImpl implements KeycloakCredentialsServic
 
   private String retrieveKcClientSecret(String realm, String clientId) {
     if (Boolean.TRUE.equals(keycloakClientProperties.getSecureStoreDisabled())) {
-      log.info("retrieveKcClientSecret:: Secure store is disabled. Using default client secret");
+      log.info("retrieveKcClientSecret:: Secure store is disabled. Using default client secret for clientId: {}", clientId);
       return "SecretPassword";
     }
     try {
       log.info("retrieveKcClientSecret:: Retrieving client secret from secure store");
       return secureStore.get("%s_%s_%s".formatted(folioEnvironment, realm, clientId));
     } catch (NotFoundException e) {
-      log.error("retrieveKcClientSecret:: Client secret not found in secure store [clientId: {}]", clientId);
+      log.error("retrieveKcClientSecret:: Client secret not found in secure store for clientId: {}", clientId);
       throw new IllegalStateException("Failed to get value from secure store [clientId: %s]".formatted(clientId), e);
     }
   }

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakCredentialsServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakCredentialsServiceImpl.java
@@ -1,0 +1,87 @@
+package org.folio.consortia.service.impl;
+
+import java.time.Instant;
+import java.util.HashMap;
+
+import org.folio.consortia.client.KeycloakClient;
+import org.folio.consortia.config.keycloak.KeycloakLoginClientProperties;
+import org.folio.consortia.config.keycloak.KeycloakProperties;
+import org.folio.consortia.domain.dto.KeycloakClientCredentials;
+import org.folio.consortia.service.KeycloakCredentialsService;
+import org.folio.tools.store.SecureStore;
+import org.folio.tools.store.exception.NotFoundException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class KeycloakCredentialsServiceImpl implements KeycloakCredentialsService {
+
+  private static final String MASTER_REALM = "master";
+  private static final String MASTER_TOKEN_CACHE_KEY = "'keycloak-admin-cli-token'";
+
+  private final KeycloakClient keycloakClient;
+  private final KeycloakProperties keycloakProperties;
+  private final KeycloakLoginClientProperties keycloakClientProperties;
+  private final SecureStore secureStore;
+  private final TaskScheduler asyncTaskScheduler;
+
+  @Value("${folio.environment}")
+  private String folioEnvironment;
+
+  @Cacheable(cacheNames = "keycloak-credentials", key = "{#centralTenant, #memberTenant}")
+  public KeycloakClientCredentials getClientCredentials(String centralTenant, String memberTenant) {
+    var clientId = memberTenant + keycloakClientProperties.getClientNameSuffix();
+    var clientSecret = retrieveKcClientSecret(centralTenant, clientId);
+    return new KeycloakClientCredentials(clientId, clientSecret);
+  }
+
+  @Cacheable(cacheNames = "keycloak-token", key = MASTER_TOKEN_CACHE_KEY)
+  public String getMasterAuthToken() {
+    var clientId = keycloakProperties.getClientId();
+    var clientSecret = retrieveKcClientSecret(MASTER_REALM, clientId);
+
+    HashMap<String, String> loginRequest = new HashMap<>();
+    loginRequest.put("client_id", clientId);
+    loginRequest.put("client_secret", clientSecret);
+    loginRequest.put("grant_type", keycloakProperties.getGrantType());
+
+    log.info("requestToken:: Issuing access token for Keycloak communication [clientId: {}]", clientId);
+    var token = keycloakClient.login(loginRequest);
+
+    if (token.getExpiresIn() != null) {
+      // Evict token 60 seconds before expiration time
+      var expirationTime = Instant.now().plusSeconds(token.getExpiresIn()).minusSeconds(60);
+      asyncTaskScheduler.schedule(this::evictMasterAuthToken, expirationTime);
+    }
+
+    return token.getTokenType() + " " + token.getAccessToken();
+  }
+
+  @CacheEvict(cacheNames = "keycloak-token", key = MASTER_TOKEN_CACHE_KEY)
+  public void evictMasterAuthToken() {
+    log.info("evictMasterAuthToken:: Evicting master realm admin token from cache");
+  }
+
+  private String retrieveKcClientSecret(String realm, String clientId) {
+    if (Boolean.TRUE.equals(keycloakClientProperties.getSecureStoreDisabled())) {
+      log.info("retrieveKcClientSecret:: Secure store is disabled. Using default client secret");
+      return "SecretPassword";
+    }
+    try {
+      log.info("retrieveKcClientSecret:: Retrieving client secret from secure store");
+      return secureStore.get("%s_%s_%s".formatted(folioEnvironment, realm, clientId));
+    } catch (NotFoundException e) {
+      log.error("retrieveKcClientSecret:: Client secret not found in secure store [clientId: {}]", clientId);
+      throw new IllegalStateException("Failed to get value from secure store [clientId: %s]".formatted(clientId), e);
+    }
+  }
+
+}

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakCredentialsServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakCredentialsServiceImpl.java
@@ -39,12 +39,12 @@ public class KeycloakCredentialsServiceImpl implements KeycloakCredentialsServic
   private String folioEnvironment;
 
   @Cacheable(cacheNames = "keycloak-credentials", key = "{#centralTenant, #memberTenant}")
-  public KeycloakClientCredentials getClientCredentials(String centralTenant, String memberTenant) {
-    var clientId = memberTenant + keycloakClientProperties.getClientNameSuffix();
-    var clientCredentials = keycloakClient.getClientCredentials(memberTenant, clientId, getMasterAuthToken());
+  public KeycloakClientCredentials getClientCredentials(String tenantId, String token) {
+    var clientId = tenantId + keycloakClientProperties.getClientNameSuffix();
+    var clientCredentials = keycloakClient.getClientCredentials(tenantId, clientId, token);
     if (CollectionUtils.isEmpty(clientCredentials) || BooleanUtils.isNotTrue(clientCredentials.get(0).getEnabled())) {
-      log.error("getClientCredentials:: Failed to get client credentials for tenant: {}", memberTenant);
-      throw new IllegalStateException("Failed to get client credentials for tenant: %s".formatted(memberTenant));
+      log.error("getClientCredentials:: Failed to get client credentials for tenant: {}", tenantId);
+      throw new IllegalStateException("Failed to get client credentials for tenant: %s".formatted(tenantId));
     }
     return clientCredentials.get(0);
   }

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
@@ -3,7 +3,7 @@ package org.folio.consortia.service.impl;
 import static org.folio.consortia.utils.KeycloakUtils.buildIdpClientConfig;
 import static org.folio.consortia.utils.KeycloakUtils.formatTenantField;
 
-import org.folio.common.configuration.properties.FolioEnvironment;
+import org.apache.commons.lang3.BooleanUtils;
 import org.folio.consortia.client.KeycloakClient;
 import org.folio.consortia.config.keycloak.KeycloakIdentityProviderProperties;
 import org.folio.consortia.config.keycloak.KeycloakLoginClientProperties;
@@ -12,6 +12,7 @@ import org.folio.consortia.domain.dto.KeycloakIdentityProvider;
 import org.folio.consortia.service.KeycloakService;
 import org.folio.tools.store.SecureStore;
 import org.folio.tools.store.exception.NotFoundException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -27,12 +28,14 @@ public class KeycloakServiceImpl implements KeycloakService {
   private final KeycloakProperties keycloakProperties;
   private final KeycloakLoginClientProperties keycloakClientProperties;
   private final KeycloakIdentityProviderProperties keycloakIdpProperties;
-  private final FolioEnvironment folioEnvironment;
   private final SecureStore secureStore;
+
+  @Value("${folio.environment}")
+  private String folioEnvironment;
 
   @Override
   public void createIdentityProvider(String centralTenant, String memberTenant) {
-    if (!Boolean.TRUE.equals(keycloakIdpProperties.getIsEnabled())) {
+    if (isIdpCreationDisabled()) {
       log.info("createIdentityProvider:: Identity provider creation is disabled. Skipping creation for tenant {}", memberTenant);
       return;
     }
@@ -51,7 +54,6 @@ public class KeycloakServiceImpl implements KeycloakService {
     val idp = KeycloakIdentityProvider.builder()
       .alias(providerAlias)
       .displayName(providerDisplayName)
-      .enabled(keycloakIdpProperties.getIsEnabled())
       .config(clientConfig)
       .build();
 
@@ -60,7 +62,7 @@ public class KeycloakServiceImpl implements KeycloakService {
 
   @Override
   public void deleteIdentityProvider(String centralTenant, String memberTenant) {
-    if (!isIdpCreationEnabled()) {
+    if (isIdpCreationDisabled()) {
       log.info("deleteIdentityProvider:: Identity provider creation is disabled. Skipping deletion for tenant {}", memberTenant);
       return;
     }
@@ -76,15 +78,15 @@ public class KeycloakServiceImpl implements KeycloakService {
     }
     try {
       log.info("retrieveKcClientSecret:: Retrieving client secret from secure store");
-      return secureStore.get("%s_%s_%s".formatted(folioEnvironment.getEnvironment(), realm, clientId));
+      return secureStore.get("%s_%s_%s".formatted(folioEnvironment, realm, clientId));
     } catch (NotFoundException e) {
       throw new IllegalStateException(String.format(
         "Failed to get value from secure store [clientId: %s]", clientId), e);
     }
   }
 
-  private boolean isIdpCreationEnabled() {
-    return Boolean.TRUE.equals(keycloakIdpProperties.getIsEnabled());
+  private boolean isIdpCreationDisabled() {
+    return BooleanUtils.isNotTrue(keycloakIdpProperties.getEnabled());
   }
 
 }

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
@@ -6,7 +6,6 @@ import static org.folio.consortia.utils.KeycloakUtils.formatTenantField;
 import org.apache.commons.lang3.BooleanUtils;
 import org.folio.consortia.client.KeycloakClient;
 import org.folio.consortia.config.keycloak.KeycloakIdentityProviderProperties;
-import org.folio.consortia.config.keycloak.KeycloakProperties;
 import org.folio.consortia.domain.dto.KeycloakIdentityProvider;
 import org.folio.consortia.service.KeycloakCredentialsService;
 import org.folio.consortia.service.KeycloakService;
@@ -25,7 +24,6 @@ public class KeycloakServiceImpl implements KeycloakService {
   private static final String KEYCLOAK_PROVIDER_ID = "keycloak-oidc";
 
   private final KeycloakClient keycloakClient;
-  private final KeycloakProperties keycloakProperties;
   private final KeycloakIdentityProviderProperties keycloakIdpProperties;
   private final KeycloakCredentialsService keycloakCredentialsService;
 
@@ -45,7 +43,7 @@ public class KeycloakServiceImpl implements KeycloakService {
 
     var providerDisplayName = formatTenantField(keycloakIdpProperties.getDisplayName(), memberTenant);
     var clientCredentials = keycloakCredentialsService.getClientCredentials(centralTenant, memberTenant);
-    var clientConfig = buildIdpClientConfig(keycloakIdpProperties.getBaseUrl(), memberTenant, clientCredentials.clientId(), clientCredentials.clientSecret());
+    var clientConfig = buildIdpClientConfig(keycloakIdpProperties.getBaseUrl(), memberTenant, clientCredentials.getClientId(), clientCredentials.getSecret());
     val idp = KeycloakIdentityProvider.builder()
       .alias(providerAlias)
       .displayName(providerDisplayName)

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
@@ -1,7 +1,6 @@
 package org.folio.consortia.service.impl;
 
 import static org.folio.consortia.utils.KeycloakUtils.buildIdpClientConfig;
-import static org.folio.consortia.utils.KeycloakUtils.formatTenantField;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -35,14 +34,14 @@ public class KeycloakServiceImpl implements KeycloakService {
       return;
     }
     log.info("createIdentityProvider:: Creating identity provider for tenant {} in central realm {}", memberTenant, centralTenant);
-    var providerAlias = formatTenantField(keycloakIdpProperties.getAlias(), memberTenant);
+    var providerAlias = memberTenant + keycloakIdpProperties.getAlias();
 
     if (identityProviderExists(centralTenant, providerAlias)) {
       log.info("createIdentityProvider:: Identity provider {} already exists for tenant {} in central realm {}", providerAlias, memberTenant, centralTenant);
       return;
     }
 
-    var providerDisplayName = formatTenantField(keycloakIdpProperties.getDisplayName(), StringUtils.capitalize(memberTenant));
+    var providerDisplayName = StringUtils.capitalize(memberTenant) + " " + keycloakIdpProperties.getDisplayName();
     var clientCredentials = keycloakCredentialsService.getClientCredentials(memberTenant, getToken());
     var clientConfig = buildIdpClientConfig(keycloakIdpProperties.getBaseUrl(), memberTenant, clientCredentials.getClientId(), clientCredentials.getSecret());
     val idp = KeycloakIdentityProvider.builder()
@@ -63,7 +62,7 @@ public class KeycloakServiceImpl implements KeycloakService {
     }
 
     log.info("deleteIdentityProvider:: Deleting identity provider for realm {}", memberTenant);
-    var providerAlias = formatTenantField(keycloakIdpProperties.getAlias(), memberTenant);
+    var providerAlias = memberTenant + keycloakIdpProperties.getAlias();
 
     if (!identityProviderExists(centralTenant, providerAlias)) {
       log.info("deleteIdentityProvider:: Identity provider {} does not exist for tenant {} in central realm {}", providerAlias, memberTenant, centralTenant);

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
@@ -45,7 +45,7 @@ public class KeycloakServiceImpl implements KeycloakService {
 
     var providerDisplayName = formatTenantField(keycloakIdpProperties.getDisplayName(), memberTenant);
     var clientCredentials = keycloakCredentialsService.getClientCredentials(centralTenant, memberTenant);
-    var clientConfig = buildIdpClientConfig(keycloakProperties.getUrl(), memberTenant, clientCredentials.clientId(), clientCredentials.clientSecret());
+    var clientConfig = buildIdpClientConfig(keycloakIdpProperties.getBaseUrl(), memberTenant, clientCredentials.clientId(), clientCredentials.clientSecret());
     val idp = KeycloakIdentityProvider.builder()
       .alias(providerAlias)
       .displayName(providerDisplayName)

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
@@ -28,22 +28,22 @@ public class KeycloakServiceImpl implements KeycloakService {
   private final KeycloakCredentialsService keycloakCredentialsService;
 
   @Override
-  public void createIdentityProvider(String centralTenant, String memberTenant) {
+  public void createIdentityProvider(String centralTenantId, String memberTenantId) {
     if (isIdpCreationDisabled()) {
-      log.info("createIdentityProvider:: Identity provider creation is disabled. Skipping creation for tenant {}", memberTenant);
+      log.info("createIdentityProvider:: Identity provider creation is disabled. Skipping creation for tenant {}", memberTenantId);
       return;
     }
-    log.info("createIdentityProvider:: Creating identity provider for tenant {} in central realm {}", memberTenant, centralTenant);
-    var providerAlias = memberTenant + keycloakIdpProperties.getAlias();
+    log.info("createIdentityProvider:: Creating identity provider for tenant {} in central realm {}", memberTenantId, centralTenantId);
+    var providerAlias = memberTenantId + keycloakIdpProperties.getAlias();
 
-    if (identityProviderExists(centralTenant, providerAlias)) {
-      log.info("createIdentityProvider:: Identity provider {} already exists for tenant {} in central realm {}", providerAlias, memberTenant, centralTenant);
+    if (identityProviderExists(centralTenantId, providerAlias)) {
+      log.info("createIdentityProvider:: Identity provider {} already exists for tenant {} in central realm {}", providerAlias, memberTenantId, centralTenantId);
       return;
     }
 
-    var providerDisplayName = StringUtils.capitalize(memberTenant) + " " + keycloakIdpProperties.getDisplayName();
-    var clientCredentials = keycloakCredentialsService.getClientCredentials(memberTenant, getToken());
-    var clientConfig = buildIdpClientConfig(keycloakIdpProperties.getBaseUrl(), memberTenant, clientCredentials.getClientId(), clientCredentials.getSecret());
+    var providerDisplayName = StringUtils.capitalize(memberTenantId) + " " + keycloakIdpProperties.getDisplayName();
+    var clientCredentials = keycloakCredentialsService.getClientCredentials(memberTenantId, getToken());
+    var clientConfig = buildIdpClientConfig(keycloakIdpProperties.getBaseUrl(), memberTenantId, clientCredentials.getClientId(), clientCredentials.getSecret());
     val idp = KeycloakIdentityProvider.builder()
       .alias(providerAlias)
       .displayName(providerDisplayName)
@@ -51,25 +51,25 @@ public class KeycloakServiceImpl implements KeycloakService {
       .config(clientConfig)
       .build();
 
-    keycloakClient.createIdentityProvider(centralTenant, idp, getToken());
+    keycloakClient.createIdentityProvider(centralTenantId, idp, getToken());
   }
 
   @Override
-  public void deleteIdentityProvider(String centralTenant, String memberTenant) {
+  public void deleteIdentityProvider(String centralTenantId, String memberTenantId) {
     if (isIdpCreationDisabled()) {
-      log.info("deleteIdentityProvider:: Identity provider creation is disabled. Skipping deletion for tenant {}", memberTenant);
+      log.info("deleteIdentityProvider:: Identity provider creation is disabled. Skipping deletion for tenant {}", memberTenantId);
       return;
     }
 
-    log.info("deleteIdentityProvider:: Deleting identity provider for realm {}", memberTenant);
-    var providerAlias = memberTenant + keycloakIdpProperties.getAlias();
+    log.info("deleteIdentityProvider:: Deleting identity provider for realm {}", memberTenantId);
+    var providerAlias = memberTenantId + keycloakIdpProperties.getAlias();
 
-    if (!identityProviderExists(centralTenant, providerAlias)) {
-      log.info("deleteIdentityProvider:: Identity provider {} does not exist for tenant {} in central realm {}", providerAlias, memberTenant, centralTenant);
+    if (!identityProviderExists(centralTenantId, providerAlias)) {
+      log.info("deleteIdentityProvider:: Identity provider {} does not exist for tenant {} in central realm {}", providerAlias, memberTenantId, centralTenantId);
       return;
     }
 
-    keycloakClient.deleteIdentityProvider(centralTenant, providerAlias, getToken());
+    keycloakClient.deleteIdentityProvider(centralTenantId, providerAlias, getToken());
   }
 
   private boolean identityProviderExists(String realm, String providerAlias) {

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
@@ -1,0 +1,55 @@
+package org.folio.consortia.service.impl;
+
+import static org.folio.consortia.utils.KeycloakUtils.buildIdentityProviderConfig;
+import static org.folio.consortia.utils.KeycloakUtils.formatTenantField;
+
+import org.folio.consortia.client.KeycloakClient;
+import org.folio.consortia.config.keycloak.KeycloakIdentityProviderProperties;
+import org.folio.consortia.config.keycloak.KeycloakProperties;
+import org.folio.consortia.domain.dto.KeycloakIdentityProvider;
+import org.folio.consortia.service.KeycloakService;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import lombok.val;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class KeycloakServiceImpl implements KeycloakService {
+
+  private final KeycloakClient keycloakClient;
+  private final KeycloakProperties keycloakProperties;
+  private final KeycloakIdentityProviderProperties keycloakIdpProperties;
+
+  @Override
+  public void createIdentityProvider(String centralTenant, String memberTenant, String clientId, String clientSecret) {
+    log.info("createIdentityProvider:: Creating identity provider for tenant {} in central realm {}", memberTenant, centralTenant);
+    var providerAlias = formatTenantField(keycloakIdpProperties.getAlias(), memberTenant);
+
+    if (keycloakClient.getIdentityProvider(centralTenant, providerAlias) != null) {
+      log.info("createIdentityProvider:: Identity provider {} already exists for tenant {} in central realm {}", providerAlias, memberTenant, centralTenant);
+      return;
+    }
+
+    var providerDisplayName = formatTenantField(keycloakIdpProperties.getDisplayName(), memberTenant);
+    var clientConfig = buildIdentityProviderConfig(keycloakProperties.getUrl(), memberTenant, clientId, clientSecret);
+    val idp = KeycloakIdentityProvider.builder()
+      .alias(providerAlias)
+      .displayName(providerDisplayName)
+      .enabled(keycloakIdpProperties.getIsEnabled())
+      .config(clientConfig)
+      .build();
+
+    keycloakClient.createIdentityProvider(centralTenant, idp);
+  }
+
+  @Override
+  public void deleteIdentityProvider(String centralRealm, String tenantRealm) {
+    log.info("deleteIdentityProvider:: Deleting identity provider for realm {}", tenantRealm);
+    var providerAlias = formatTenantField(keycloakIdpProperties.getAlias(), tenantRealm);
+    keycloakClient.deleteIdentityProvider(centralRealm, providerAlias);
+  }
+
+}

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
@@ -80,8 +80,8 @@ public class KeycloakServiceImpl implements KeycloakService {
       log.info("retrieveKcClientSecret:: Retrieving client secret from secure store");
       return secureStore.get("%s_%s_%s".formatted(folioEnvironment, realm, clientId));
     } catch (NotFoundException e) {
-      throw new IllegalStateException(String.format(
-        "Failed to get value from secure store [clientId: %s]", clientId), e);
+      log.error("retrieveKcClientSecret:: Client secret not found in secure store [clientId: {}]", clientId);
+      throw new IllegalStateException("Failed to get value from secure store [clientId: %s]".formatted(clientId), e);
     }
   }
 

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
@@ -1,13 +1,17 @@
 package org.folio.consortia.service.impl;
 
-import static org.folio.consortia.utils.KeycloakUtils.buildIdentityProviderConfig;
+import static org.folio.consortia.utils.KeycloakUtils.buildIdpClientConfig;
 import static org.folio.consortia.utils.KeycloakUtils.formatTenantField;
 
+import org.folio.common.configuration.properties.FolioEnvironment;
 import org.folio.consortia.client.KeycloakClient;
 import org.folio.consortia.config.keycloak.KeycloakIdentityProviderProperties;
+import org.folio.consortia.config.keycloak.KeycloakLoginClientProperties;
 import org.folio.consortia.config.keycloak.KeycloakProperties;
 import org.folio.consortia.domain.dto.KeycloakIdentityProvider;
 import org.folio.consortia.service.KeycloakService;
+import org.folio.tools.store.SecureStore;
+import org.folio.tools.store.exception.NotFoundException;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -21,10 +25,17 @@ public class KeycloakServiceImpl implements KeycloakService {
 
   private final KeycloakClient keycloakClient;
   private final KeycloakProperties keycloakProperties;
+  private final KeycloakLoginClientProperties keycloakClientProperties;
   private final KeycloakIdentityProviderProperties keycloakIdpProperties;
+  private final FolioEnvironment folioEnvironment;
+  private final SecureStore secureStore;
 
   @Override
-  public void createIdentityProvider(String centralTenant, String memberTenant, String clientId, String clientSecret) {
+  public void createIdentityProvider(String centralTenant, String memberTenant) {
+    if (!Boolean.TRUE.equals(keycloakIdpProperties.getIsEnabled())) {
+      log.info("createIdentityProvider:: Identity provider creation is disabled. Skipping creation for tenant {}", memberTenant);
+      return;
+    }
     log.info("createIdentityProvider:: Creating identity provider for tenant {} in central realm {}", memberTenant, centralTenant);
     var providerAlias = formatTenantField(keycloakIdpProperties.getAlias(), memberTenant);
 
@@ -34,7 +45,9 @@ public class KeycloakServiceImpl implements KeycloakService {
     }
 
     var providerDisplayName = formatTenantField(keycloakIdpProperties.getDisplayName(), memberTenant);
-    var clientConfig = buildIdentityProviderConfig(keycloakProperties.getUrl(), memberTenant, clientId, clientSecret);
+    var clientId = memberTenant + keycloakClientProperties.getClientNameSuffix();
+    var clientSecret = retrieveKcClientSecret(centralTenant, clientId);
+    var clientConfig = buildIdpClientConfig(keycloakProperties.getUrl(), memberTenant, clientId, clientSecret);
     val idp = KeycloakIdentityProvider.builder()
       .alias(providerAlias)
       .displayName(providerDisplayName)
@@ -46,10 +59,32 @@ public class KeycloakServiceImpl implements KeycloakService {
   }
 
   @Override
-  public void deleteIdentityProvider(String centralRealm, String tenantRealm) {
-    log.info("deleteIdentityProvider:: Deleting identity provider for realm {}", tenantRealm);
-    var providerAlias = formatTenantField(keycloakIdpProperties.getAlias(), tenantRealm);
-    keycloakClient.deleteIdentityProvider(centralRealm, providerAlias);
+  public void deleteIdentityProvider(String centralTenant, String memberTenant) {
+    if (!isIdpCreationEnabled()) {
+      log.info("deleteIdentityProvider:: Identity provider creation is disabled. Skipping deletion for tenant {}", memberTenant);
+      return;
+    }
+    log.info("deleteIdentityProvider:: Deleting identity provider for realm {}", memberTenant);
+    var providerAlias = formatTenantField(keycloakIdpProperties.getAlias(), memberTenant);
+    keycloakClient.deleteIdentityProvider(centralTenant, providerAlias);
+  }
+
+  private String retrieveKcClientSecret(String realm, String clientId) {
+    if (Boolean.TRUE.equals(keycloakClientProperties.getSecureStoreDisabled())) {
+      log.info("retrieveKcClientSecret:: Secure store is disabled. Using default client secret");
+      return "SecretPassword";
+    }
+    try {
+      log.info("retrieveKcClientSecret:: Retrieving client secret from secure store");
+      return secureStore.get("%s_%s_%s".formatted(folioEnvironment.getEnvironment(), realm, clientId));
+    } catch (NotFoundException e) {
+      throw new IllegalStateException(String.format(
+        "Failed to get value from secure store [clientId: %s]", clientId), e);
+    }
+  }
+
+  private boolean isIdpCreationEnabled() {
+    return Boolean.TRUE.equals(keycloakIdpProperties.getIsEnabled());
   }
 
 }

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakServiceImpl.java
@@ -4,6 +4,7 @@ import static org.folio.consortia.utils.KeycloakUtils.buildIdpClientConfig;
 import static org.folio.consortia.utils.KeycloakUtils.formatTenantField;
 
 import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.consortia.client.KeycloakClient;
 import org.folio.consortia.config.keycloak.KeycloakIdentityProviderProperties;
 import org.folio.consortia.domain.dto.KeycloakIdentityProvider;
@@ -41,8 +42,8 @@ public class KeycloakServiceImpl implements KeycloakService {
       return;
     }
 
-    var providerDisplayName = formatTenantField(keycloakIdpProperties.getDisplayName(), memberTenant);
-    var clientCredentials = keycloakCredentialsService.getClientCredentials(centralTenant, memberTenant);
+    var providerDisplayName = formatTenantField(keycloakIdpProperties.getDisplayName(), StringUtils.capitalize(memberTenant));
+    var clientCredentials = keycloakCredentialsService.getClientCredentials(memberTenant, getToken());
     var clientConfig = buildIdpClientConfig(keycloakIdpProperties.getBaseUrl(), memberTenant, clientCredentials.getClientId(), clientCredentials.getSecret());
     val idp = KeycloakIdentityProvider.builder()
       .alias(providerAlias)

--- a/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java
@@ -145,6 +145,16 @@ public class TenantManagerImpl implements TenantManager {
     log.info("delete:: Tenant '{}' in consortium '{}' was successfully deleted", tenantId, consortiumId);
   }
 
+  @Override
+  public void createIdentityProvider(String memberTenant) {
+    keycloakService.createIdentityProvider(folioExecutionContext.getTenantId(), memberTenant);
+  }
+
+  @Override
+  public void deleteIdentityProvider(String memberTenant) {
+    keycloakService.deleteIdentityProvider(folioExecutionContext.getTenantId(), memberTenant);
+  }
+
   private void createCustomFieldIfNeeded(String tenant) {
     systemUserScopedExecutionService.executeSystemUserScoped(tenant, () -> {
         if (isNotEmpty(customFieldService.getCustomFieldByName(ORIGINAL_TENANT_ID_NAME))) {

--- a/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java
@@ -124,9 +124,10 @@ public class TenantManagerImpl implements TenantManager {
     if (isHardDelete) {
       cleanupService.clearSharingTables(tenantId);
       // Delete identity provider for member tenant if it is being hard deleted
-      if (!folioExecutionContext.getTenantId().equals(tenantId)) {
-        keycloakService.deleteIdentityProvider(folioExecutionContext.getTenantId(), tenantId);
-      }
+//      TODO: Disabled temporarily until tested
+//      if (!folioExecutionContext.getTenantId().equals(tenantId)) {
+//        keycloakService.deleteIdentityProvider(folioExecutionContext.getTenantId(), tenantId);
+//      }
     }
     tenantService.deleteTenant(tenant, tenantDeleteRequest.getDeleteType());
 

--- a/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java
@@ -26,6 +26,7 @@ import org.folio.consortia.service.CapabilitiesUserService;
 import org.folio.consortia.service.CleanupService;
 import org.folio.consortia.service.ConsortiumService;
 import org.folio.consortia.service.CustomFieldService;
+import org.folio.consortia.service.KeycloakService;
 import org.folio.consortia.service.LockService;
 import org.folio.consortia.service.SyncPrimaryAffiliationService;
 import org.folio.consortia.service.TenantManager;
@@ -53,6 +54,7 @@ public class TenantManagerImpl implements TenantManager {
   private static final String DUMMY_USERNAME = "dummy_user";
 
   private final TenantService tenantService;
+  private final KeycloakService keycloakService;
   private final ConsortiumService consortiumService;
   private final ConsortiaConfigurationClient configurationClient;
   private final SyncPrimaryAffiliationService syncPrimaryAffiliationService;
@@ -121,6 +123,8 @@ public class TenantManagerImpl implements TenantManager {
     // Clean sharing tables or shadow users if needed
     if (isHardDelete) {
       cleanupService.clearSharingTables(tenantId);
+      // Delete identity provider for member tenant if it is being hard deleted
+      keycloakService.deleteIdentityProvider(folioExecutionContext.getTenantId(), tenantId);
     }
     tenantService.deleteTenant(tenant, tenantDeleteRequest.getDeleteType());
 
@@ -192,6 +196,7 @@ public class TenantManagerImpl implements TenantManager {
       centralTenantId = tenantService.getCentralTenantId();
       shadowAdminUser = userService.prepareShadowUser(adminUserId, folioExecutionContext.getTenantId());
       tenantService.saveUserTenant(consortiumId, shadowAdminUser, tenantDto);
+      keycloakService.createIdentityProvider(centralTenantId, tenantDto.getId());
     }
 
     var finalShadowAdminUser = shadowAdminUser;

--- a/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java
@@ -124,7 +124,9 @@ public class TenantManagerImpl implements TenantManager {
     if (isHardDelete) {
       cleanupService.clearSharingTables(tenantId);
       // Delete identity provider for member tenant if it is being hard deleted
-      keycloakService.deleteIdentityProvider(folioExecutionContext.getTenantId(), tenantId);
+      if (!folioExecutionContext.getTenantId().equals(tenantId)) {
+        keycloakService.deleteIdentityProvider(folioExecutionContext.getTenantId(), tenantId);
+      }
     }
     tenantService.deleteTenant(tenant, tenantDeleteRequest.getDeleteType());
 

--- a/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java
@@ -148,13 +148,13 @@ public class TenantManagerImpl implements TenantManager {
   }
 
   @Override
-  public void createIdentityProvider(String memberTenant) {
-    keycloakService.createIdentityProvider(folioExecutionContext.getTenantId(), memberTenant);
+  public void createIdentityProvider(String memberTenantId) {
+    keycloakService.createIdentityProvider(folioExecutionContext.getTenantId(), memberTenantId);
   }
 
   @Override
-  public void deleteIdentityProvider(String memberTenant) {
-    keycloakService.deleteIdentityProvider(folioExecutionContext.getTenantId(), memberTenant);
+  public void deleteIdentityProvider(String memberTenantId) {
+    keycloakService.deleteIdentityProvider(folioExecutionContext.getTenantId(), memberTenantId);
   }
 
   private void createCustomFieldIfNeeded(String tenant) {

--- a/src/main/java/org/folio/consortia/utils/KeycloakUtils.java
+++ b/src/main/java/org/folio/consortia/utils/KeycloakUtils.java
@@ -11,7 +11,7 @@ public class KeycloakUtils {
   private static final String USER_INFO_URL = "%s/protocol/openid-connect/userinfo";
   private static final String JWKS_URL = "%s/protocol/openid-connect/certs";
 
-  public static KeycloakIdentityProvider.ClientConfig buildIdentityProviderConfig(String baseUrl, String tenantRealm, String clientId, String clientSecret) {
+  public static KeycloakIdentityProvider.ClientConfig buildIdpClientConfig(String baseUrl, String tenantRealm, String clientId, String clientSecret) {
     var realmUrl = REALM_URL.formatted(baseUrl, tenantRealm);
     return KeycloakIdentityProvider.ClientConfig.builder()
       .clientId(clientId)

--- a/src/main/java/org/folio/consortia/utils/KeycloakUtils.java
+++ b/src/main/java/org/folio/consortia/utils/KeycloakUtils.java
@@ -2,6 +2,9 @@ package org.folio.consortia.utils;
 
 import org.folio.consortia.domain.dto.KeycloakIdentityProvider;
 
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
 public class KeycloakUtils {
 
   private static final String REALM_URL = "%s/realms/%s";
@@ -10,9 +13,6 @@ public class KeycloakUtils {
   private static final String LOGOUT_URL = "%s/protocol/openid-connect/logout";
   private static final String USER_INFO_URL = "%s/protocol/openid-connect/userinfo";
   private static final String JWKS_URL = "%s/protocol/openid-connect/certs";
-
-  private KeycloakUtils() {
-  }
 
   public static KeycloakIdentityProvider.ClientConfig buildIdpClientConfig(String baseUrl, String tenantRealm, String clientId, String clientSecret) {
     var realmUrl = REALM_URL.formatted(baseUrl, tenantRealm);

--- a/src/main/java/org/folio/consortia/utils/KeycloakUtils.java
+++ b/src/main/java/org/folio/consortia/utils/KeycloakUtils.java
@@ -32,8 +32,4 @@ public class KeycloakUtils {
       .build();
   }
 
-  public static String formatTenantField(String template, String tenantId) {
-    return template.replace("{tenantId}", tenantId);
-  }
-
 }

--- a/src/main/java/org/folio/consortia/utils/KeycloakUtils.java
+++ b/src/main/java/org/folio/consortia/utils/KeycloakUtils.java
@@ -1,0 +1,36 @@
+package org.folio.consortia.utils;
+
+import org.folio.consortia.domain.dto.KeycloakIdentityProvider;
+
+public class KeycloakUtils {
+
+  private static final String REALM_URL = "%s/realms/%s";
+  private static final String AUTHORIZATION_URL = "%s/protocol/openid-connect/auth";
+  private static final String TOKEN_URL = "%s/protocol/openid-connect/token";
+  private static final String LOGOUT_URL = "%s/protocol/openid-connect/logout";
+  private static final String USER_INFO_URL = "%s/protocol/openid-connect/userinfo";
+  private static final String JWKS_URL = "%s/protocol/openid-connect/certs";
+
+  public static KeycloakIdentityProvider.ClientConfig buildIdentityProviderConfig(String baseUrl, String tenantRealm, String clientId, String clientSecret) {
+    var realmUrl = REALM_URL.formatted(baseUrl, tenantRealm);
+    return KeycloakIdentityProvider.ClientConfig.builder()
+      .clientId(clientId)
+      .clientSecret(clientSecret)
+      .clientAuthMethod("client_secret_post")
+      .authorizationUrl(AUTHORIZATION_URL.formatted(realmUrl))
+      .tokenUrl(TOKEN_URL.formatted(realmUrl))
+      .logoutUrl(LOGOUT_URL.formatted(realmUrl))
+      .userInfoUrl(USER_INFO_URL.formatted(realmUrl))
+      .issuer(realmUrl)
+      .jwksUrl(JWKS_URL.formatted(realmUrl))
+      .validateSignature(true)
+      .useJwksUrl(true)
+      .pkceEnabled(false)
+      .build();
+  }
+
+  public static String formatTenantField(String template, String tenantId) {
+    return template.replace("{tenantId}", tenantId);
+  }
+
+}

--- a/src/main/java/org/folio/consortia/utils/KeycloakUtils.java
+++ b/src/main/java/org/folio/consortia/utils/KeycloakUtils.java
@@ -11,6 +11,9 @@ public class KeycloakUtils {
   private static final String USER_INFO_URL = "%s/protocol/openid-connect/userinfo";
   private static final String JWKS_URL = "%s/protocol/openid-connect/certs";
 
+  private KeycloakUtils() {
+  }
+
   public static KeycloakIdentityProvider.ClientConfig buildIdpClientConfig(String baseUrl, String tenantRealm, String clientId, String clientSecret) {
     var realmUrl = REALM_URL.formatted(baseUrl, tenantRealm);
     return KeycloakIdentityProvider.ClientConfig.builder()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,13 +85,13 @@ folio:
       trust-store-path: ${KC_CLIENT_TLS_TRUSTSTORE_PATH:}
       trust-store-password: ${KC_CLIENT_TLS_TRUSTSTORE_PASSWORD:}
       trust-store-type: ${KC_CLIENT_TLS_TRUSTSTORE_TYPE:}
-  login:
-    client-name-suffix: ${KC_LOGIN_CLIENT_SUFFIX:-login-application}
-    secure-store-disabled: ${KC_ADMIN_SECURE_STORE_ENABLED:true}
-  identity-provider:
-    enabled: ${SINGLE_TENANT_UX:false}
-    alias: ${IDENTITY_PROVIDER_ALIAS:{tenantId}-keycloak-oidc}
-    display-name: ${IDENTITY_PROVIDER_DISPLAY_NAME:{tenantId} Keycloak OIDC}
+    login:
+      client-name-suffix: ${KC_LOGIN_CLIENT_SUFFIX:-login-application}
+      secure-store-disabled: ${KC_ADMIN_SECURE_STORE_ENABLED:true}
+    identity-provider:
+      enabled: ${SINGLE_TENANT_UX:false}
+      alias: ${IDENTITY_PROVIDER_ALIAS:{tenantId}-keycloak-oidc}
+      display-name: ${IDENTITY_PROVIDER_DISPLAY_NAME:{tenantId} Keycloak OIDC}
 feign:
   client:
     config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -104,8 +104,8 @@ application:
     login:
       client-name-suffix: ${KC_LOGIN_CLIENT_SUFFIX:-login-application}
     identity-provider:
-      enabled: ${SINGLE_TENANT_UX:false}
-      base-url: ${IDENTITY_PROVIDER_BASE_URL:${folio.keycloak.url}}
+      enabled: ${SINGLE_TENANT_UX:true}
+      base-url: ${KC_IDENTITY_PROVIDER_BASE_URL:https://${folio.environment}-keycloak.ci.folio.org}
       alias: ${IDENTITY_PROVIDER_SUFFIX:-keycloak-oidc}
       display-name: ${IDENTITY_PROVIDER_DISPLAY_SUFFIX:Keycloak OIDC}
 feign:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -94,8 +94,8 @@ application:
       truststore-file-path: ${SECRET_STORE_VAULT_TRUSTSTORE_FILE_PATH:}
   keycloak:
     url: ${KC_URL:http://keycloak:8080}
-    grant-type: ${KC_ADMIN_GRANT_TYPE:client_credentials}
     client-id: ${KC_ADMIN_CLIENT_ID:folio-backend-admin-client}
+    grant-type: ${KC_ADMIN_GRANT_TYPE:client_credentials}
     tls:
       enabled: ${KC_CLIENT_TLS_ENABLED:false}
       trust-store-path: ${KC_CLIENT_TLS_TRUSTSTORE_PATH:}
@@ -104,10 +104,10 @@ application:
     login:
       client-name-suffix: ${KC_LOGIN_CLIENT_SUFFIX:-login-application}
     identity-provider:
-      enabled: ${SINGLE_TENANT_UX:true}
-      base-url: ${KC_IDENTITY_PROVIDER_BASE_URL:https://${folio.environment}-keycloak.ci.folio.org}
-      alias: ${IDENTITY_PROVIDER_SUFFIX:-keycloak-oidc}
-      display-name: ${IDENTITY_PROVIDER_DISPLAY_SUFFIX:Keycloak OIDC}
+      enabled: ${SINGLE_TENANT_UX:false}
+      base-url: ${KC_IDENTITY_PROVIDER_BASE_URL:${application.keycloak.url}}
+      alias: ${KC_IDENTITY_PROVIDER_SUFFIX:-keycloak-oidc}
+      display-name: ${KC_IDENTITY_PROVIDER_DISPLAY_SUFFIX:Keycloak OIDC}
 feign:
   client:
     config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,7 +78,7 @@ folio:
   max-active-threads: 5
 application:
   secret-store:
-    type: ${SECRET_STORE_TYPE:AWS_SSM}
+    type: ${SECRET_STORE_TYPE:EPHEMERAL}
     aws-ssm:
       region: ${SECRET_STORE_AWS_SSM_REGION:}
       use-iam: ${SECRET_STORE_AWS_SSM_USE_IAM:true}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,7 +87,7 @@ folio:
       trust-store-type: ${KC_CLIENT_TLS_TRUSTSTORE_TYPE:}
     login:
       client-name-suffix: ${KC_LOGIN_CLIENT_SUFFIX:-login-application}
-      secure-store-disabled: ${KC_ADMIN_SECURE_STORE_ENABLED:true}
+      secure-store-disabled: ${KC_ADMIN_SECURE_STORE_DISABLED:false}
     identity-provider:
       enabled: ${SINGLE_TENANT_UX:false}
       alias: ${IDENTITY_PROVIDER_ALIAS:{tenantId}-keycloak-oidc}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,6 +76,22 @@ folio:
   timer:
     publication-records-max-age-in-seconds: 86400
   max-active-threads: 5
+application:
+  secret-store:
+    type: ${SECRET_STORE_TYPE:aws-ssm}
+    aws-ssm:
+      region: ${SECRET_STORE_AWS_SSM_REGION:}
+      use-iam: ${SECRET_STORE_AWS_SSM_USE_IAM:true}
+      ecs-credentials-endpoint: ${SECRET_STORE_AWS_SSM_ECS_CREDENTIALS_ENDPOINT:}
+      ecs-credentials-path: ${SECRET_STORE_AWS_SSM_ECS_CREDENTIALS_PATH:}
+    vault:
+      token: ${SECRET_STORE_VAULT_TOKEN:}
+      address: ${SECRET_STORE_VAULT_ADDRESS:}
+      enable-ssl: ${SECRET_STORE_VAULT_ENABLE_SSL:false}
+      pem-file-path: ${SECRET_STORE_VAULT_PEM_FILE_PATH:}
+      keystore-password: ${SECRET_STORE_VAULT_KEYSTORE_PASSWORD:}
+      keystore-file-path: ${SECRET_STORE_VAULT_KEYSTORE_FILE_PATH:}
+      truststore-file-path: ${SECRET_STORE_VAULT_TRUSTSTORE_FILE_PATH:}
   keycloak:
     url: ${KC_URL:http://keycloak:8080}
     grant-type: ${KC_ADMIN_GRANT_TYPE:client_credentials}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,7 +78,7 @@ folio:
   max-active-threads: 5
 application:
   secret-store:
-    type: ${SECRET_STORE_TYPE:aws-ssm}
+    type: ${SECRET_STORE_TYPE:AWS_SSM}
     aws-ssm:
       region: ${SECRET_STORE_AWS_SSM_REGION:}
       use-iam: ${SECRET_STORE_AWS_SSM_USE_IAM:true}
@@ -103,12 +103,11 @@ application:
       trust-store-type: ${KC_CLIENT_TLS_TRUSTSTORE_TYPE:}
     login:
       client-name-suffix: ${KC_LOGIN_CLIENT_SUFFIX:-login-application}
-      secure-store-disabled: ${KC_ADMIN_SECURE_STORE_DISABLED:false}
     identity-provider:
       enabled: ${SINGLE_TENANT_UX:false}
       base-url: ${IDENTITY_PROVIDER_BASE_URL:${folio.keycloak.url}}
-      alias: ${IDENTITY_PROVIDER_ALIAS:{tenantId}-keycloak-oidc}
-      display-name: ${IDENTITY_PROVIDER_DISPLAY_NAME:{tenantId} Keycloak OIDC}
+      alias: ${IDENTITY_PROVIDER_SUFFIX:-keycloak-oidc}
+      display-name: ${IDENTITY_PROVIDER_DISPLAY_SUFFIX:Keycloak OIDC}
 feign:
   client:
     config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -90,6 +90,7 @@ folio:
       secure-store-disabled: ${KC_ADMIN_SECURE_STORE_DISABLED:false}
     identity-provider:
       enabled: ${SINGLE_TENANT_UX:false}
+      base-url: ${IDENTITY_PROVIDER_BASE_URL:${folio.keycloak.url}}
       alias: ${IDENTITY_PROVIDER_ALIAS:{tenantId}-keycloak-oidc}
       display-name: ${IDENTITY_PROVIDER_DISPLAY_NAME:{tenantId} Keycloak OIDC}
 feign:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,6 +85,9 @@ folio:
       trust-store-path: ${KC_CLIENT_TLS_TRUSTSTORE_PATH:}
       trust-store-password: ${KC_CLIENT_TLS_TRUSTSTORE_PASSWORD:}
       trust-store-type: ${KC_CLIENT_TLS_TRUSTSTORE_TYPE:}
+  login:
+    client-name-suffix: ${KC_LOGIN_CLIENT_SUFFIX:-login-application}
+    secure-store-disabled: ${KC_ADMIN_SECURE_STORE_ENABLED:true}
   identity-provider:
     enabled: ${SINGLE_TENANT_UX:false}
     alias: ${IDENTITY_PROVIDER_ALIAS:{tenantId}-keycloak-oidc}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,6 +76,19 @@ folio:
   timer:
     publication-records-max-age-in-seconds: 86400
   max-active-threads: 5
+  keycloak:
+    url: ${KC_URL:http://keycloak:8080}
+    grant-type: ${KC_ADMIN_GRANT_TYPE:client_credentials}
+    client-id: ${KC_ADMIN_CLIENT_ID:folio-backend-admin-client}
+    tls:
+      enabled: ${KC_CLIENT_TLS_ENABLED:false}
+      trust-store-path: ${KC_CLIENT_TLS_TRUSTSTORE_PATH:}
+      trust-store-password: ${KC_CLIENT_TLS_TRUSTSTORE_PASSWORD:}
+      trust-store-type: ${KC_CLIENT_TLS_TRUSTSTORE_TYPE:}
+  identity-provider:
+    enabled: ${SINGLE_TENANT_UX:false}
+    alias: ${IDENTITY_PROVIDER_ALIAS:{tenantId}-keycloak-oidc}
+    display-name: ${IDENTITY_PROVIDER_DISPLAY_NAME:{tenantId} Keycloak OIDC}
 feign:
   client:
     config:

--- a/src/main/resources/swagger.api/tenants.yaml
+++ b/src/main/resources/swagger.api/tenants.yaml
@@ -138,6 +138,37 @@ paths:
           $ref: "#/components/responses/Conflict"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /tenants/{tenantId}/identity-provider:
+    post:
+      summary: Create keycloak identity provider for member tenant in central tenant realm
+      operationId: createIdentityProvider
+      parameters:
+        - $ref: "#/components/parameters/consortiumId"
+        - $ref: "#/components/parameters/tenantId"
+      responses:
+        "201":
+          $ref: "#/components/responses/Created"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    delete:
+      summary: Delete keycloak identity provider of member tenant from central tenant realm
+      operationId: deleteIdentityProvider
+      parameters:
+        - $ref: "#/components/parameters/consortiumId"
+        - $ref: "#/components/parameters/tenantId"
+      responses:
+        "204":
+          $ref: "#/components/responses/NoContent"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 components:
   requestBodies:
     TenantBody:
@@ -179,6 +210,8 @@ components:
         application/json:
           schema:
             $ref: "schemas/tenant.yaml#/TenantCollection"
+    Created:
+      description: Created
     NoContent:
       description: No content
     Conflict:

--- a/src/test/java/org/folio/consortia/controller/TenantControllerTest.java
+++ b/src/test/java/org/folio/consortia/controller/TenantControllerTest.java
@@ -1,5 +1,6 @@
 package org.folio.consortia.controller;
 
+import static org.folio.consortia.support.EntityUtils.TENANT_ID;
 import static org.folio.consortia.support.EntityUtils.createTenant;
 import static org.folio.consortia.support.EntityUtils.createTenantDeleteRequest;
 import static org.folio.consortia.support.EntityUtils.createTenantDetailsEntity;
@@ -56,6 +57,7 @@ import org.folio.consortia.repository.ConsortiumRepository;
 import org.folio.consortia.repository.TenantDetailsRepository;
 import org.folio.consortia.repository.TenantRepository;
 import org.folio.consortia.repository.UserTenantRepository;
+import org.folio.consortia.service.KeycloakService;
 import org.folio.consortia.service.SyncPrimaryAffiliationService;
 import org.folio.consortia.service.TenantService;
 import org.folio.consortia.service.UserService;
@@ -87,6 +89,7 @@ class TenantControllerTest extends BaseIT {
     "/consortia/%s/tenants/%s/sync-primary-affiliations?centralTenantId=%s";
   public static final String PRIMARY_AFFILIATIONS_URL =
     "/consortia/%s/tenants/%s/create-primary-affiliations?centralTenantId=%s";
+  public static final String IDENTITY_PROVIDER_URL = "/consortia/%s/tenants/%s/identity-provider";
 
   @MockBean
   ConsortiumRepository consortiumRepository;
@@ -118,6 +121,8 @@ class TenantControllerTest extends BaseIT {
   UserTenantsClient userTenantsClient;
   @MockBean
   SyncPrimaryAffiliationService syncPrimaryAffiliationService;
+  @MockBean
+  KeycloakService keycloakService;
   @MockBean
   UsersKeycloakClient usersKeycloakClient;
   @MockBean
@@ -476,6 +481,28 @@ class TenantControllerTest extends BaseIT {
     this.mockMvc.perform(
         post(String.format(PRIMARY_AFFILIATIONS_URL, consortiumId, tenantId, centralTenantId)).headers(headers)
           .content(spabString))
+      .andExpectAll(status().isNoContent());
+  }
+
+  @Test
+  void testCreateIdentityProvider() throws Exception {
+    var headers = defaultHeaders();
+    var consortiumId = UUID.randomUUID();
+    doNothing().when(keycloakService).createIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
+
+    this.mockMvc
+      .perform(post(String.format(IDENTITY_PROVIDER_URL, consortiumId, TENANT_ID)).headers(headers))
+      .andExpectAll(status().isCreated());
+  }
+
+  @Test
+  void testDeleteIdentityProvider() throws Exception {
+    var headers = defaultHeaders();
+    var consortiumId = UUID.randomUUID();
+    doNothing().when(keycloakService).deleteIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
+
+    this.mockMvc
+      .perform(delete(String.format(IDENTITY_PROVIDER_URL, consortiumId, TENANT_ID)).headers(headers))
       .andExpectAll(status().isNoContent());
   }
 

--- a/src/test/java/org/folio/consortia/service/ConsortiumServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/ConsortiumServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.data.domain.PageImpl;
 
@@ -28,6 +29,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest
+@Profile("test")
 @EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
 class ConsortiumServiceTest {
 

--- a/src/test/java/org/folio/consortia/service/KeycloakCredentialsServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/KeycloakCredentialsServiceTest.java
@@ -105,20 +105,6 @@ class KeycloakCredentialsServiceTest {
   }
 
   @Test
-  void getMasterAuthToken_returnsValidToken_secureStoreDisabled() {
-    String clientId = "clientId";
-    when(keycloakProperties.getClientId()).thenReturn(clientId);
-    when(keycloakClient.login(anyMap())).thenReturn(createTokenResponse());
-    when(keycloakClientProperties.getSecureStoreDisabled()).thenReturn(true);
-
-    String token = keycloakCredentialsService.getMasterAuthToken();
-
-    assertEquals(AUTH_TOKEN, token);
-    verify(secureStore, never()).get(anyString());
-    verify(asyncTaskScheduler).schedule(any(Runnable.class), any(Instant.class));
-  }
-
-  @Test
   void getMasterAuthToken_throwsException_secretNotFound() {
     String clientId = "clientId";
     when(keycloakProperties.getClientId()).thenReturn(clientId);

--- a/src/test/java/org/folio/consortia/service/KeycloakCredentialsServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/KeycloakCredentialsServiceTest.java
@@ -53,14 +53,12 @@ class KeycloakCredentialsServiceTest {
 
   @Test
   void getClientCredentials_returnsValidCredentials() {
-    String centralTenant = "central";
     String memberTenant = "member";
     when(keycloakClientProperties.getClientNameSuffix()).thenReturn("-suffix");
-    when(keycloakClient.login(anyMap())).thenReturn(createTokenResponse());
     when(keycloakClient.getClientCredentials(memberTenant, memberTenant + "-suffix", AUTH_TOKEN))
       .thenReturn(List.of(createClientCredentials(memberTenant + "-suffix", "secret", true)));
 
-    KeycloakClientCredentials credentials = keycloakCredentialsService.getClientCredentials(centralTenant, memberTenant);
+    KeycloakClientCredentials credentials = keycloakCredentialsService.getClientCredentials(memberTenant, AUTH_TOKEN);
 
     assertEquals("member-suffix", credentials.getClientId());
     assertEquals("secret", credentials.getSecret());
@@ -69,27 +67,23 @@ class KeycloakCredentialsServiceTest {
 
   @Test
   void getClientCredentials_throwsException_clientNotFound() {
-    String centralTenant = "central";
     String memberTenant = "member";
     when(keycloakClientProperties.getClientNameSuffix()).thenReturn("-suffix");
-    when(keycloakClient.login(anyMap())).thenReturn(createTokenResponse());
     when(keycloakClient.getClientCredentials(memberTenant, memberTenant + "-suffix", AUTH_TOKEN))
       .thenReturn(List.of());
 
-    assertThrows(IllegalStateException.class, () -> keycloakCredentialsService.getClientCredentials(centralTenant, memberTenant));
+    assertThrows(IllegalStateException.class, () -> keycloakCredentialsService.getClientCredentials(memberTenant, AUTH_TOKEN));
     verify(keycloakClient).getClientCredentials(memberTenant, "member-suffix", AUTH_TOKEN);
   }
 
   @Test
   void getClientCredentials_throwsException_clientNotEnabled() {
-    String centralTenant = "central";
     String memberTenant = "member";
     when(keycloakClientProperties.getClientNameSuffix()).thenReturn("-suffix");
-    when(keycloakClient.login(anyMap())).thenReturn(createTokenResponse());
     when(keycloakClient.getClientCredentials(memberTenant, memberTenant + "-suffix", AUTH_TOKEN))
       .thenReturn(List.of(createClientCredentials(memberTenant + "-suffix", "secret", false)));
 
-    assertThrows(IllegalStateException.class, () -> keycloakCredentialsService.getClientCredentials(centralTenant, memberTenant));
+    assertThrows(IllegalStateException.class, () -> keycloakCredentialsService.getClientCredentials(memberTenant, AUTH_TOKEN));
     verify(keycloakClient).getClientCredentials(memberTenant, "member-suffix", AUTH_TOKEN);
   }
 

--- a/src/test/java/org/folio/consortia/service/KeycloakCredentialsServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/KeycloakCredentialsServiceTest.java
@@ -1,0 +1,133 @@
+package org.folio.consortia.service;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.folio.consortia.client.KeycloakClient;
+import org.folio.consortia.config.keycloak.KeycloakLoginClientProperties;
+import org.folio.consortia.config.keycloak.KeycloakProperties;
+import org.folio.consortia.domain.dto.KeycloakClientCredentials;
+import org.folio.consortia.domain.dto.KeycloakTokenResponse;
+import org.folio.consortia.service.impl.KeycloakCredentialsServiceImpl;
+import org.folio.consortia.support.CopilotGenerated;
+import org.folio.tools.store.SecureStore;
+import org.folio.tools.store.exception.NotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+@CopilotGenerated(partiallyGenerated = true)
+@ExtendWith(MockitoExtension.class)
+class KeycloakCredentialsServiceTest {
+
+  @Mock
+  private KeycloakClient keycloakClient;
+  @Mock
+  private KeycloakProperties keycloakProperties;
+  @Mock
+  private KeycloakLoginClientProperties keycloakClientProperties;
+  @Mock
+  private SecureStore secureStore;
+  @Spy
+  private TaskScheduler asyncTaskScheduler = new SimpleAsyncTaskScheduler();
+
+  @InjectMocks
+  @Spy
+  private KeycloakCredentialsServiceImpl keycloakCredentialsService;
+
+  @Value("${folio.environment}")
+  private String folioEnvironment;
+
+  @Test
+  void getClientCredentials_returnsValidCredentials() {
+    String centralTenant = "central";
+    String memberTenant = "member";
+    when(keycloakClientProperties.getClientNameSuffix()).thenReturn("-suffix");
+    when(secureStore.get(anyString())).thenReturn("secret");
+
+    KeycloakClientCredentials credentials = keycloakCredentialsService.getClientCredentials(centralTenant, memberTenant);
+
+    assertEquals("member-suffix", credentials.clientId());
+    assertEquals("secret", credentials.clientSecret());
+    verify(secureStore).get("%s_%s_%s".formatted(folioEnvironment, "central", "member-suffix"));
+  }
+
+  @Test
+  void getClientCredentials_returnsValidCredentials_secureStoreDisabled() {
+    String centralTenant = "central";
+    String memberTenant = "member";
+    when(keycloakClientProperties.getClientNameSuffix()).thenReturn("-suffix");
+    when(keycloakClientProperties.getSecureStoreDisabled()).thenReturn(true);
+
+    KeycloakClientCredentials credentials = keycloakCredentialsService.getClientCredentials(centralTenant, memberTenant);
+
+    assertEquals("member-suffix", credentials.clientId());
+    assertEquals("SecretPassword", credentials.clientSecret());
+    verify(secureStore, never()).get("%s_%s_%s".formatted(folioEnvironment, "central", "member-suffix"));
+  }
+
+  @Test
+  void getClientCredentials_throwsExceptionIfSecretNotFound() {
+    String centralTenant = "central";
+    String memberTenant = "member";
+    when(keycloakClientProperties.getClientNameSuffix()).thenReturn("-suffix");
+    when(secureStore.get(anyString())).thenThrow(new NotFoundException("Not found"));
+
+    assertThrows(IllegalStateException.class, () -> keycloakCredentialsService.getClientCredentials(centralTenant, memberTenant));
+  }
+
+  @Test
+  void getMasterAuthToken_returnsValidToken() {
+    String clientId = "clientId";
+    String clientSecret = "clientSecret";
+    var tokenResponse = createTokenResponse();
+
+    when(keycloakProperties.getClientId()).thenReturn(clientId);
+    when(secureStore.get(anyString())).thenReturn(clientSecret);
+    when(keycloakClient.login(anyMap())).thenReturn(tokenResponse);
+
+    String token = keycloakCredentialsService.getMasterAuthToken();
+
+    assertEquals("Bearer accessToken", token);
+    verify(asyncTaskScheduler).schedule(any(Runnable.class), any(Instant.class));
+  }
+
+  @Test
+  void getMasterAuthToken_evictsTokenAfterExpiry() {
+    String clientId = "clientId";
+    String clientSecret = "clientSecret";
+    var tokenResponse = createTokenResponse();
+    tokenResponse.setExpiresIn(65L);
+
+    when(keycloakProperties.getClientId()).thenReturn(clientId);
+    when(secureStore.get(anyString())).thenReturn(clientSecret);
+    when(keycloakClient.login(anyMap())).thenReturn(tokenResponse);
+
+    String token = keycloakCredentialsService.getMasterAuthToken();
+
+    assertEquals("Bearer accessToken", token);
+    verify(asyncTaskScheduler).schedule(any(Runnable.class), any(Instant.class));
+    await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+      verify(keycloakCredentialsService).evictMasterAuthToken();
+    });
+  }
+
+  private static KeycloakTokenResponse createTokenResponse() {
+    KeycloakTokenResponse tokenResponse = new KeycloakTokenResponse();
+    tokenResponse.setTokenType("Bearer");
+    tokenResponse.setAccessToken("accessToken");
+    tokenResponse.setExpiresIn(3600L);
+    return tokenResponse;
+  }
+
+}

--- a/src/test/java/org/folio/consortia/service/KeycloakServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/KeycloakServiceTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 import org.folio.consortia.client.KeycloakClient;
 import org.folio.consortia.config.keycloak.KeycloakIdentityProviderProperties;
 import org.folio.consortia.config.keycloak.KeycloakLoginClientProperties;
-import org.folio.consortia.domain.dto.KeycloakClientCredentials;
 import org.folio.consortia.domain.dto.KeycloakIdentityProvider;
 import org.folio.consortia.service.impl.KeycloakServiceImpl;
 import org.folio.consortia.support.CopilotGenerated;
@@ -66,7 +65,7 @@ class KeycloakServiceTest {
     var clientId = TENANT_ID + keycloakLoginClientProperties.getClientNameSuffix();
     when(keycloakClient.getIdentityProvider(CENTRAL_TENANT_ID, alias, AUTH_TOKEN))
       .thenThrow(new FeignException.NotFound("not found", mock(Request.class), new byte[0], null));
-    when(keycloakCredentialsService.getClientCredentials(CENTRAL_TENANT_ID, TENANT_ID))
+    when(keycloakCredentialsService.getClientCredentials(TENANT_ID, AUTH_TOKEN))
       .thenReturn(createClientCredentials(clientId, CLIENT_SECRET, true));
 
     keycloakService.createIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);

--- a/src/test/java/org/folio/consortia/service/KeycloakServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/KeycloakServiceTest.java
@@ -21,8 +21,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
@@ -31,7 +29,6 @@ import feign.FeignException;
 import feign.Request;
 
 @SpringBootTest
-@EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
 @CopilotGenerated(partiallyGenerated = true)
 class KeycloakServiceTest {
 

--- a/src/test/java/org/folio/consortia/service/KeycloakServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/KeycloakServiceTest.java
@@ -1,5 +1,6 @@
 package org.folio.consortia.service;
 
+import static org.folio.consortia.service.KeycloakCredentialsServiceTest.createClientCredentials;
 import static org.folio.consortia.support.EntityUtils.CENTRAL_TENANT_ID;
 import static org.folio.consortia.support.EntityUtils.TENANT_ID;
 import static org.mockito.ArgumentMatchers.any;
@@ -57,16 +58,16 @@ class KeycloakServiceTest {
   void setUp() {
     when(keycloakIdpProperties.getEnabled()).thenReturn(true);
     when(keycloakCredentialsService.getMasterAuthToken()).thenReturn(AUTH_TOKEN);
-    when(keycloakCredentialsService.getClientCredentials(anyString(), anyString()))
-      .thenReturn(new KeycloakClientCredentials(TENANT_ID, CLIENT_SECRET));
   }
 
   @Test
   void createIdentityProvider_createsProviderSuccessfully() {
     var alias = getTenantClientAlias(TENANT_ID);
-    when(keycloakLoginClientProperties.getSecureStoreDisabled()).thenReturn(true);
+    var clientId = TENANT_ID + keycloakLoginClientProperties.getClientNameSuffix();
     when(keycloakClient.getIdentityProvider(CENTRAL_TENANT_ID, alias, AUTH_TOKEN))
       .thenThrow(new FeignException.NotFound("not found", mock(Request.class), new byte[0], null));
+    when(keycloakCredentialsService.getClientCredentials(CENTRAL_TENANT_ID, TENANT_ID))
+      .thenReturn(createClientCredentials(clientId, CLIENT_SECRET, true));
 
     keycloakService.createIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
 

--- a/src/test/java/org/folio/consortia/service/KeycloakServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/KeycloakServiceTest.java
@@ -1,0 +1,116 @@
+package org.folio.consortia.service;
+
+import static org.folio.consortia.support.EntityUtils.CENTRAL_TENANT_ID;
+import static org.folio.consortia.support.EntityUtils.TENANT_ID;
+import static org.mockito.Mockito.*;
+
+import org.folio.consortia.client.KeycloakClient;
+import org.folio.consortia.config.keycloak.KeycloakIdentityProviderProperties;
+import org.folio.consortia.config.keycloak.KeycloakLoginClientProperties;
+import org.folio.consortia.domain.dto.KeycloakIdentityProvider;
+import org.folio.consortia.service.impl.KeycloakServiceImpl;
+import org.folio.consortia.support.CopilotGenerated;
+import org.folio.tools.store.SecureStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+@SpringBootTest
+@EnableAutoConfiguration(exclude = BatchAutoConfiguration.class)
+@CopilotGenerated(partiallyGenerated = true)
+class KeycloakServiceTest {
+
+  @MockBean
+  private KeycloakClient keycloakClient;
+  @MockBean
+  private SecureStore secureStore;
+  @SpyBean
+  private KeycloakIdentityProviderProperties keycloakIdpProperties;
+  @SpyBean
+  private KeycloakLoginClientProperties keycloakLoginClientProperties;
+
+  @Autowired
+  private KeycloakServiceImpl keycloakService;
+  @Value("${folio.environment}")
+  private String folioEnvironment;
+
+  @BeforeEach
+  void setUp() {
+    when(keycloakIdpProperties.getEnabled()).thenReturn(true);
+  }
+
+  @Test
+  void createIdentityProvider_createsProviderSuccessfully() {
+    var alias = getTenantClientAlias(TENANT_ID);
+    when(keycloakClient.getIdentityProvider(CENTRAL_TENANT_ID, alias)).thenReturn(null);
+    when(keycloakLoginClientProperties.getSecureStoreDisabled()).thenReturn(true);
+
+    keycloakService.createIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
+
+    verify(keycloakClient).getIdentityProvider(CENTRAL_TENANT_ID, alias);
+    verify(keycloakClient).createIdentityProvider(eq(CENTRAL_TENANT_ID), any(KeycloakIdentityProvider.class));
+  }
+
+  @Test
+  void createIdentityProvider_createsProviderSuccessfully_secureStoreEnabled() {
+    var alias = getTenantClientAlias(TENANT_ID);
+    var clientId = TENANT_ID + keycloakLoginClientProperties.getClientNameSuffix();
+    when(keycloakClient.getIdentityProvider(CENTRAL_TENANT_ID, alias)).thenReturn(null);
+    when(keycloakLoginClientProperties.getSecureStoreDisabled()).thenReturn(false);
+    when(secureStore.get("%s_%s_%s".formatted(folioEnvironment, CENTRAL_TENANT_ID, clientId))).thenReturn("secret");
+
+    keycloakService.createIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
+
+    verify(keycloakClient).getIdentityProvider(CENTRAL_TENANT_ID, alias);
+    verify(keycloakClient).createIdentityProvider(eq(CENTRAL_TENANT_ID), any(KeycloakIdentityProvider.class));
+  }
+
+  @Test
+  void createIdentityProvider_skipsIfDisabled() {
+    var alias = getTenantClientAlias(TENANT_ID);
+    when(keycloakIdpProperties.getEnabled()).thenReturn(false);
+
+    keycloakService.createIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
+
+    verify(keycloakClient, never()).getIdentityProvider(CENTRAL_TENANT_ID, alias);
+    verify(keycloakClient, never()).createIdentityProvider(anyString(), any(KeycloakIdentityProvider.class));
+  }
+
+  @Test
+  void createIdentityProvider_skipsIfProviderExists() {
+    var alias = getTenantClientAlias(TENANT_ID);
+    when(keycloakClient.getIdentityProvider(CENTRAL_TENANT_ID, alias)).thenReturn(new KeycloakIdentityProvider());
+
+    keycloakService.createIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
+
+    verify(keycloakClient).getIdentityProvider(CENTRAL_TENANT_ID, alias);
+    verify(keycloakClient, never()).createIdentityProvider(anyString(), any(KeycloakIdentityProvider.class));
+  }
+
+  @Test
+  void deleteIdentityProvider_deletesProviderSuccessfully() {
+    keycloakService.deleteIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
+
+    verify(keycloakClient).deleteIdentityProvider(CENTRAL_TENANT_ID, getTenantClientAlias(TENANT_ID));
+  }
+
+  @Test
+  void deleteIdentityProvider_skipsIfDisabled() {
+    when(keycloakIdpProperties.getEnabled()).thenReturn(false);
+
+    keycloakService.deleteIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
+
+    verify(keycloakClient, never()).deleteIdentityProvider(anyString(), anyString());
+  }
+
+  private static String getTenantClientAlias(String tenant) {
+    return tenant + "-keycloak-oidc";
+  }
+
+}

--- a/src/test/java/org/folio/consortia/service/TenantManagerTest.java
+++ b/src/test/java/org/folio/consortia/service/TenantManagerTest.java
@@ -366,7 +366,7 @@ class TenantManagerTest {
     doNothing().when(cleanupService).clearPublicationTables();
     doNothing().when(tenantRepository).delete(tenant);
     doNothing().when(userTenantRepository).deleteUserTenantsByTenantId(TENANT_ID);
-    doNothing().when(keycloakService).deleteIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
+//    doNothing().when(keycloakService).deleteIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
     mockOkapiHeaders();
     when(tenantRepository.findById(tenant.getId())).thenReturn(Optional.of(tenant));
     when(executionContextBuilder.buildContext(anyString())).thenReturn(folioExecutionContext);
@@ -384,7 +384,7 @@ class TenantManagerTest {
     verify(cleanupService).clearPublicationTables();
     verify(tenantRepository).delete(tenant);
     verify(userTenantRepository).deleteUserTenantsByTenantId(TENANT_ID);
-    verify(keycloakService).deleteIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
+//    verify(keycloakService).deleteIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
   }
 
   @Test

--- a/src/test/java/org/folio/consortia/service/TenantManagerTest.java
+++ b/src/test/java/org/folio/consortia/service/TenantManagerTest.java
@@ -576,4 +576,22 @@ class TenantManagerTest {
     assertEquals(tenant, tenant1);
   }
 
+  @Test
+  void testCreateIdentityProvider() {
+    when(folioExecutionContext.getTenantId()).thenReturn(CENTRAL_TENANT_ID);
+
+    tenantManager.createIdentityProvider(TENANT_ID);
+
+    verify(keycloakService).createIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
+  }
+
+  @Test
+  void testDeleteIdentityProvider() {
+    when(folioExecutionContext.getTenantId()).thenReturn(CENTRAL_TENANT_ID);
+
+    tenantManager.deleteIdentityProvider(TENANT_ID);
+
+    verify(keycloakService).deleteIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
+  }
+
 }

--- a/src/test/java/org/folio/consortia/service/TenantManagerTest.java
+++ b/src/test/java/org/folio/consortia/service/TenantManagerTest.java
@@ -110,6 +110,8 @@ class TenantManagerTest {
   private SystemUserScopedExecutionService systemUserScopedExecutionService;
   @Mock
   private CustomFieldService customFieldService;
+  @Mock
+  private KeycloakService keycloakService;
 
   private TenantManager tenantManager;
   private TenantService tenantService;
@@ -117,7 +119,7 @@ class TenantManagerTest {
   @BeforeEach
   void setUp() {
     tenantService = new TenantServiceImpl(tenantRepository, userTenantRepository, tenantDetailsRepository, conversionService, consortiumService, folioExecutionContext);
-    tenantManager = new TenantManagerImpl(tenantService, consortiumService, consortiaConfigurationClient, syncPrimaryAffiliationService, userService, capabilitiesUserService,
+    tenantManager = new TenantManagerImpl(tenantService, keycloakService, consortiumService, consortiaConfigurationClient, syncPrimaryAffiliationService, userService, capabilitiesUserService,
       customFieldService, cleanupService, lockService, userTenantsClient, systemUserScopedExecutionService, executionContextBuilder, folioExecutionContext);
   }
 
@@ -364,9 +366,11 @@ class TenantManagerTest {
     doNothing().when(cleanupService).clearPublicationTables();
     doNothing().when(tenantRepository).delete(tenant);
     doNothing().when(userTenantRepository).deleteUserTenantsByTenantId(TENANT_ID);
+    doNothing().when(keycloakService).deleteIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
+    mockOkapiHeaders();
     when(tenantRepository.findById(tenant.getId())).thenReturn(Optional.of(tenant));
     when(executionContextBuilder.buildContext(anyString())).thenReturn(folioExecutionContext);
-    mockOkapiHeaders();
+    when(folioExecutionContext.getTenantId()).thenReturn(CENTRAL_TENANT_ID);
 
     tenantManager.delete(consortiumId, TENANT_ID, deleteRequest);
 
@@ -380,6 +384,7 @@ class TenantManagerTest {
     verify(cleanupService).clearPublicationTables();
     verify(tenantRepository).delete(tenant);
     verify(userTenantRepository).deleteUserTenantsByTenantId(TENANT_ID);
+    verify(keycloakService).deleteIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
   }
 
   @Test
@@ -525,7 +530,7 @@ class TenantManagerTest {
     when(conversionService.convert(tenantDetailsEntity, Tenant.class)).thenReturn(tenant);
     when(userService.prepareShadowUser(any(UUID.class), anyString())).thenReturn(adminUser);
     when(userTenantRepository.save(any(UserTenantEntity.class))).thenReturn(new UserTenantEntity());
-
+    doNothing().when(keycloakService).createIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
     doNothing().when(consortiaConfigurationClient).saveConfiguration(any());
     when(userTenantsClient.getUserTenants()).thenReturn(new UserTenantCollection(List.of(), 1));
 
@@ -535,6 +540,7 @@ class TenantManagerTest {
     verify(userTenantRepository, times(1)).save(any());
     verify(consortiaConfigurationClient).saveConfiguration(any());
     verify(lockService).lockTenantSetupWithinTransaction();
+    verify(keycloakService).createIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
     verify(userTenantsClient, never()).postUserTenant(any());
     verify(userService, never()).getById(any());
     verify(userService, never()).createUser(any());
@@ -565,6 +571,7 @@ class TenantManagerTest {
 
     verify(userTenantsClient, never()).postUserTenant(any());
     verify(customFieldService, never()).createCustomField(any());
+    verify(keycloakService, never()).createIdentityProvider(any(), any());
 
     assertEquals(tenant, tenant1);
   }

--- a/src/test/java/org/folio/consortia/utils/KeycloakUtilsTest.java
+++ b/src/test/java/org/folio/consortia/utils/KeycloakUtilsTest.java
@@ -31,14 +31,4 @@ class KeycloakUtilsTest {
     assertFalse(config.isPkceEnabled());
   }
 
-  @Test
-  void formatTenantField_replacesTenantId() {
-    String template = "tenant-{tenantId}-field";
-    String tenantId = "12345";
-
-    String result = KeycloakUtils.formatTenantField(template, tenantId);
-
-    assertEquals("tenant-12345-field", result);
-  }
-
 }

--- a/src/test/java/org/folio/consortia/utils/KeycloakUtilsTest.java
+++ b/src/test/java/org/folio/consortia/utils/KeycloakUtilsTest.java
@@ -1,0 +1,64 @@
+package org.folio.consortia.utils;
+
+import org.folio.consortia.domain.dto.KeycloakIdentityProvider;
+import org.folio.consortia.support.CopilotGenerated;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+@CopilotGenerated
+class KeycloakUtilsTest {
+
+  @Test
+  void buildIdpClientConfig_createsValidConfig() {
+    String baseUrl = "http://localhost";
+    String tenantRealm = "testRealm";
+    String clientId = "testClient";
+    String clientSecret = "testSecret";
+
+    KeycloakIdentityProvider.ClientConfig config = KeycloakUtils.buildIdpClientConfig(baseUrl, tenantRealm, clientId, clientSecret);
+
+    assertEquals(clientId, config.getClientId());
+    assertEquals(clientSecret, config.getClientSecret());
+    assertEquals("client_secret_post", config.getClientAuthMethod());
+    assertEquals("http://localhost/realms/testRealm/protocol/openid-connect/auth", config.getAuthorizationUrl());
+    assertEquals("http://localhost/realms/testRealm/protocol/openid-connect/token", config.getTokenUrl());
+    assertEquals("http://localhost/realms/testRealm/protocol/openid-connect/logout", config.getLogoutUrl());
+    assertEquals("http://localhost/realms/testRealm/protocol/openid-connect/userinfo", config.getUserInfoUrl());
+    assertEquals("http://localhost/realms/testRealm", config.getIssuer());
+    assertEquals("http://localhost/realms/testRealm/protocol/openid-connect/certs", config.getJwksUrl());
+    assertTrue(config.isValidateSignature());
+    assertTrue(config.isUseJwksUrl());
+    assertFalse(config.isPkceEnabled());
+  }
+
+  @Test
+  void formatTenantField_replacesTenantId() {
+    String template = "tenant-{tenantId}-field";
+    String tenantId = "12345";
+
+    String result = KeycloakUtils.formatTenantField(template, tenantId);
+
+    assertEquals("tenant-12345-field", result);
+  }
+
+  @Test
+  void formatTenantField_handlesEmptyTenantId() {
+    String template = "tenant-{tenantId}-field";
+    String tenantId = "";
+
+    String result = KeycloakUtils.formatTenantField(template, tenantId);
+
+    assertEquals("tenant--field", result);
+  }
+
+  @Test
+  void formatTenantField_handlesNoPlaceholder() {
+    String template = "tenant-field";
+    String tenantId = "12345";
+
+    String result = KeycloakUtils.formatTenantField(template, tenantId);
+
+    assertEquals("tenant-field", result);
+  }
+
+}

--- a/src/test/java/org/folio/consortia/utils/KeycloakUtilsTest.java
+++ b/src/test/java/org/folio/consortia/utils/KeycloakUtilsTest.java
@@ -41,24 +41,4 @@ class KeycloakUtilsTest {
     assertEquals("tenant-12345-field", result);
   }
 
-  @Test
-  void formatTenantField_handlesEmptyTenantId() {
-    String template = "tenant-{tenantId}-field";
-    String tenantId = "";
-
-    String result = KeycloakUtils.formatTenantField(template, tenantId);
-
-    assertEquals("tenant--field", result);
-  }
-
-  @Test
-  void formatTenantField_handlesNoPlaceholder() {
-    String template = "tenant-field";
-    String tenantId = "12345";
-
-    String result = KeycloakUtils.formatTenantField(template, tenantId);
-
-    assertEquals("tenant-field", result);
-  }
-
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -47,7 +47,7 @@ folio:
       client-name-suffix: ${KC_LOGIN_CLIENT_SUFFIX:-login-application}
       secure-store-disabled: ${KC_ADMIN_SECURE_STORE_ENABLED:true}
     identity-provider:
-      enabled: ${SINGLE_TENANT_UX:false}
+      enabled: ${SINGLE_TENANT_UX:true}
       alias: ${IDENTITY_PROVIDER_ALIAS:{tenantId}-keycloak-oidc}
       display-name: ${IDENTITY_PROVIDER_DISPLAY_NAME:{tenantId} Keycloak OIDC}
 management:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -34,22 +34,6 @@ folio:
   tenant:
     validation:
       enabled: false
-  keycloak:
-    url: ${KC_URL:http://keycloak:8080}
-    grant-type: ${KC_ADMIN_GRANT_TYPE:client_credentials}
-    client-id: ${KC_ADMIN_CLIENT_ID:folio-backend-admin-client}
-    tls:
-      enabled: ${KC_CLIENT_TLS_ENABLED:false}
-      trust-store-path: ${KC_CLIENT_TLS_TRUSTSTORE_PATH:}
-      trust-store-password: ${KC_CLIENT_TLS_TRUSTSTORE_PASSWORD:}
-      trust-store-type: ${KC_CLIENT_TLS_TRUSTSTORE_TYPE:}
-    login:
-      client-name-suffix: ${KC_LOGIN_CLIENT_SUFFIX:-login-application}
-      secure-store-disabled: ${KC_ADMIN_SECURE_STORE_ENABLED:true}
-    identity-provider:
-      enabled: ${SINGLE_TENANT_UX:true}
-      alias: ${IDENTITY_PROVIDER_ALIAS:{tenantId}-keycloak-oidc}
-      display-name: ${IDENTITY_PROVIDER_DISPLAY_NAME:{tenantId} Keycloak OIDC}
 management:
   endpoints:
     enabled-by-default: false

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -27,7 +27,6 @@ folio:
         concurrency: ${KAFKA_EVENTS_CONCURRENCY:1}
         topic-pattern: ${KAFKA_EVENTS_CONSUMER_PATTERN:(${folio.environment}\.)[a-zA-z0-9-]+\.\w+\.USER_CREATED}
         group-id: ${folio.environment}-mod-consortia-keycloak-group
-
       user-deleted:
         concurrency: ${KAFKA_EVENTS_CONCURRENCY:1}
         topic-pattern: ${KAFKA_EVENTS_CONSUMER_PATTERN:(${folio.environment}\.)[a-zA-z0-9-]+\.\w+\.USER_DELETED}
@@ -35,6 +34,22 @@ folio:
   tenant:
     validation:
       enabled: false
+  keycloak:
+    url: ${KC_URL:http://keycloak:8080}
+    grant-type: ${KC_ADMIN_GRANT_TYPE:client_credentials}
+    client-id: ${KC_ADMIN_CLIENT_ID:folio-backend-admin-client}
+    tls:
+      enabled: ${KC_CLIENT_TLS_ENABLED:false}
+      trust-store-path: ${KC_CLIENT_TLS_TRUSTSTORE_PATH:}
+      trust-store-password: ${KC_CLIENT_TLS_TRUSTSTORE_PASSWORD:}
+      trust-store-type: ${KC_CLIENT_TLS_TRUSTSTORE_TYPE:}
+    login:
+      client-name-suffix: ${KC_LOGIN_CLIENT_SUFFIX:-login-application}
+      secure-store-disabled: ${KC_ADMIN_SECURE_STORE_ENABLED:true}
+    identity-provider:
+      enabled: ${SINGLE_TENANT_UX:false}
+      alias: ${IDENTITY_PROVIDER_ALIAS:{tenantId}-keycloak-oidc}
+      display-name: ${IDENTITY_PROVIDER_DISPLAY_NAME:{tenantId} Keycloak OIDC}
 management:
   endpoints:
     enabled-by-default: false


### PR DESCRIPTION
## Purpose
[[MODCONSKC-63] Create an identity provider in keycloak when adding a tenant to the consortia](https://folio-org.atlassian.net/browse/MODCONSKC-63)

## Approach
- Add keycloak properties to application.yml
- Add keycloak properties beans
- Add keycloak client with proper tls properties
- Configure and create keycloak feign client
- Create keycloak service with idp creation and delete support
- Modify tenant creation and deletion flows to include idp management

## Verification
### Initial IDPs
![image](https://github.com/user-attachments/assets/592075c6-fb33-4ccf-832d-7a58b3ef3601)

### Delete IDP
![image](https://github.com/user-attachments/assets/d6a83319-f0ab-4546-b1a8-0bb4578daeeb)

### Create IDP
![image](https://github.com/user-attachments/assets/784af4d2-03c2-42d5-9d74-2019215d5558)

### IDP Details
![image](https://github.com/user-attachments/assets/b54c047a-9308-406e-a553-e50ae3084fc2)


## Notes
Identity provider deletion was not in scope of this story, however for the sake of easier testing and idempotent create/delete operations, with current implementation identity provider for a tenant is not created if it already exists and is deleted during hard delete.