### PR TITLE
[MODCONSKC-70] Create IDP and link users during tenant creation

### DIFF
--- a/src/main/java/org/folio/consortia/service/KeycloakUsersService.java
+++ b/src/main/java/org/folio/consortia/service/KeycloakUsersService.java
@@ -5,9 +5,9 @@ public interface KeycloakUsersService {
   /**
    * Create identity provider links for users
    *
-   * @param tenantId id to of original tenant
    * @param centralTenantId central tenant id
+   * @param memberTenantId id to of original tenant
    */
-  void createUsersIdpLinks(String tenantId, String centralTenantId);
+  void createUsersIdpLinks(String centralTenantId, String memberTenantId);
 
 }

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakUsersServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakUsersServiceImpl.java
@@ -27,14 +27,14 @@ public class KeycloakUsersServiceImpl implements KeycloakUsersService {
   private final FolioExecutionContext folioExecutionContext;
 
   @Override
-  public void createUsersIdpLinks(String tenantId, String centralTenantId) {
-    log.info("createUsersIdpLinks:: Creating users IDP links created in member tenant: '{}' in central tenant: '{}'", tenantId, centralTenantId);
-    var users = getMemberTenantOriginalUsers(tenantId);
+  public void createUsersIdpLinks(String centralTenantId, String memberTenantId) {
+    log.info("createUsersIdpLinks:: Creating users IDP links created in member tenant: '{}' in central tenant: '{}'", memberTenantId, centralTenantId);
+    var users = getMemberTenantOriginalUsers(memberTenantId);
     if (CollectionUtils.isEmpty(users)) {
-      log.info("createUsersIdpLinks:: No users to create links from member tenant: '{}' to central tenant: '{}'", tenantId, centralTenantId);
+      log.info("createUsersIdpLinks:: No users to create links from member tenant: '{}' to central tenant: '{}'", memberTenantId, centralTenantId);
       return;
     }
-    log.info("createUsersIdpLinks:: Found '{}' users to create links from member tenant: '{}' to central tenant: '{}'", users.size(), tenantId, centralTenantId);
+    log.info("createUsersIdpLinks:: Found '{}' users to create links from member tenant: '{}' to central tenant: '{}'", users.size(), memberTenantId, centralTenantId);
     var userIdpLinkingRequest = new UserIdpLinkingRequest()
       .userIds(users.stream().map(User::getId).collect(Collectors.toSet()))
       .centralTenantId(centralTenantId);

--- a/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java
@@ -153,11 +153,12 @@ public class TenantManagerImpl implements TenantManager {
 
   @Override
   public void createIdentityProvider(String memberTenantId, IdentityProviderCreateRequest idpCreateRequest) {
+    var centralTenantId = tenantService.getCentralTenantId();
     if (idpCreateRequest.getCreateProvider()) {
-      keycloakService.createIdentityProvider(folioExecutionContext.getTenantId(), memberTenantId);
+      keycloakService.createIdentityProvider(centralTenantId, memberTenantId);
     }
     if (idpCreateRequest.getMigrateUsers()) {
-      keycloakUsersService.createUsersIdpLinks(memberTenantId, tenantService.getCentralTenantId());
+      keycloakUsersService.createUsersIdpLinks(centralTenantId, memberTenantId);
     }
   }
 

--- a/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java
@@ -87,7 +87,6 @@ public class TenantManagerImpl implements TenantManager {
 
     createCustomFieldIfNeeded(tenantDto.getId());
     setUpCentralCustomAuthFlow(tenantDto.getId(), tenantDto.getIsCentral());
-    createIdentityProvider(tenantDto.getId(), new IdentityProviderCreateRequest(true, true));
 
     var existingTenant = tenantService.getByTenantId(tenantDto.getId());
     return existingTenant != null
@@ -225,7 +224,7 @@ public class TenantManagerImpl implements TenantManager {
       centralTenantId = tenantService.getCentralTenantId();
       shadowAdminUser = userService.prepareShadowUser(adminUserId, folioExecutionContext.getTenantId());
       tenantService.saveUserTenant(consortiumId, shadowAdminUser, tenantDto);
-      keycloakService.createIdentityProvider(centralTenantId, tenantDto.getId());
+      createIdentityProvider(tenantDto.getId(), new IdentityProviderCreateRequest(true, true));
     }
 
     var finalShadowAdminUser = shadowAdminUser;

--- a/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java
@@ -87,6 +87,7 @@ public class TenantManagerImpl implements TenantManager {
 
     createCustomFieldIfNeeded(tenantDto.getId());
     setUpCentralCustomAuthFlow(tenantDto.getId(), tenantDto.getIsCentral());
+    createIdentityProvider(tenantDto.getId(), new IdentityProviderCreateRequest(true, true));
 
     var existingTenant = tenantService.getByTenantId(tenantDto.getId());
     return existingTenant != null

--- a/src/test/java/org/folio/consortia/service/KeycloakUsersServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/KeycloakUsersServiceTest.java
@@ -44,7 +44,7 @@ class KeycloakUsersServiceTest {
     user.setId("userId");
     when(userService.getPrimaryUsersToLink()).thenReturn(List.of(user));
 
-    keycloakUsersService.createUsersIdpLinks(TENANT_ID, CENTRAL_TENANT_ID);
+    keycloakUsersService.createUsersIdpLinks(CENTRAL_TENANT_ID, TENANT_ID);
 
     verify(usersKeycloakClient).createUsersIdpLinks(any(UserIdpLinkingRequest.class));
   }
@@ -53,7 +53,7 @@ class KeycloakUsersServiceTest {
   void testCreateUsersIdpLinksNoUsersToLink() {
     when(userService.getPrimaryUsersToLink()).thenReturn(Collections.emptyList());
 
-    keycloakUsersService.createUsersIdpLinks(TENANT_ID, CENTRAL_TENANT_ID);
+    keycloakUsersService.createUsersIdpLinks(CENTRAL_TENANT_ID, TENANT_ID);
 
     verify(usersKeycloakClient, never()).createUsersIdpLinks(any(UserIdpLinkingRequest.class));
   }

--- a/src/test/java/org/folio/consortia/service/TenantManagerTest.java
+++ b/src/test/java/org/folio/consortia/service/TenantManagerTest.java
@@ -589,7 +589,7 @@ class TenantManagerTest {
     tenantManager.createIdentityProvider(TENANT_ID, idpCreateRequest);
 
     verify(keycloakService).createIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
-    verify(keycloakUsersService).createUsersIdpLinks(TENANT_ID, CENTRAL_TENANT_ID);
+    verify(keycloakUsersService).createUsersIdpLinks(CENTRAL_TENANT_ID, TENANT_ID);
   }
 
   @Test


### PR DESCRIPTION
## Purpose
[[MODCONSKC-70] Create IDP and link users during tenant creation](https://folio-org.atlassian.net/browse/MODCONSKC-70)

## Approach
Create IDP and link users during tenant creation