### PR TITLE
[MODCONSKC-69] Add support for deleting related module's data for consortia tenant hard delete

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -235,7 +235,8 @@
             "perms.users.assign.immutable",
             "perms.users.assign.mutable",
             "users.collection.get",
-            "user-tenants.collection.get"
+            "user-tenants.collection.get",
+            "users-keycloak.idp-migrations.post"
           ]
         },
         {
@@ -259,7 +260,10 @@
             "consortia.tenants.item.delete"
           ],
           "modulePermissions": [
-            "consortia.consortia-configuration.item.delete"
+            "consortia.consortia-configuration.item.delete",
+            "users-keycloak.idp-migrations.delete",
+            "users-keycloak.item.delete",
+            "user-tenants.item.delete"
           ]
         },
         {
@@ -311,7 +315,9 @@
           "permissionsRequired": [
             "consortia.identity-provider.item.post"
           ],
-          "modulePermissions": []
+          "modulePermissions": [
+            "users-keycloak.idp-migrations.post"
+          ]
         },
         {
           "methods": [
@@ -321,7 +327,9 @@
           "permissionsRequired": [
             "consortia.identity-provider.item.delete"
           ],
-          "modulePermissions": []
+          "modulePermissions": [
+            "users-keycloak.idp-migrations.delete"
+          ]
         },
         {
           "methods": [

--- a/src/main/java/org/folio/consortia/client/UserTenantsClient.java
+++ b/src/main/java/org/folio/consortia/client/UserTenantsClient.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "user-tenants" , configuration = FeignClientConfiguration.class)
 public interface UserTenantsClient {
@@ -21,4 +22,7 @@ public interface UserTenantsClient {
 
   @DeleteMapping
   void deleteUserTenants();
+
+  @DeleteMapping
+  void deleteUserTenantsByTenantId(@RequestParam("tenantId") String tenantId);
 }

--- a/src/main/java/org/folio/consortia/client/UsersKeycloakClient.java
+++ b/src/main/java/org/folio/consortia/client/UsersKeycloakClient.java
@@ -1,7 +1,7 @@
 package org.folio.consortia.client;
 
 import org.folio.consortia.domain.dto.User;
-import org.folio.consortia.domain.dto.UserIdpLinkingRequest;
+import org.folio.consortia.domain.dto.UsersIdpLinkOperationRequest;
 import org.folio.spring.config.FeignClientConfiguration;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
@@ -28,6 +28,9 @@ public interface UsersKeycloakClient {
   void deleteUser(@PathVariable String userId);
 
   @PostMapping(value = "/idp-migrations", consumes = MediaType.APPLICATION_JSON_VALUE)
-  void createUsersIdpLinks(@RequestBody UserIdpLinkingRequest userIdpLinkingRequest);
+  void createUsersIdpLinks(@RequestBody UsersIdpLinkOperationRequest usersIdpLinkOperationRequest);
+
+  @DeleteMapping(value = "/idp-migrations", consumes = MediaType.APPLICATION_JSON_VALUE)
+  void deleteUsersIdpLinks(@RequestBody UsersIdpLinkOperationRequest usersIdpLinkOperationRequest);
 
 }

--- a/src/main/java/org/folio/consortia/messaging/listener/ConsortiaSharingInstanceEventListener.java
+++ b/src/main/java/org/folio/consortia/messaging/listener/ConsortiaSharingInstanceEventListener.java
@@ -1,8 +1,10 @@
 package org.folio.consortia.messaging.listener;
 
+import static org.folio.consortia.utils.TenantContextUtils.createFolioExecutionContext;
+import static org.folio.consortia.utils.TenantContextUtils.runInFolioContext;
+
 import org.apache.commons.lang3.StringUtils;
 import org.folio.consortia.service.SharingInstanceService;
-import org.folio.consortia.utils.TenantContextUtils;
 import org.folio.spring.FolioModuleMetadata;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.messaging.MessageHeaders;
@@ -29,9 +31,8 @@ public class ConsortiaSharingInstanceEventListener {
   public void handleConsortiumInstanceSharingCompleting(String data, MessageHeaders messageHeaders) {
     String centralTenantId = eventListenerHelper.getCentralTenantByIdByHeader(messageHeaders);
     if (StringUtils.isNotBlank(centralTenantId)) {
-      TenantContextUtils.runInFolioContext(
-        TenantContextUtils.createFolioExecutionContext(messageHeaders, folioMetadata, centralTenantId), () ->
-        sharingInstanceService.completePromotingLocalInstance(data));
+      runInFolioContext(createFolioExecutionContext(messageHeaders, folioMetadata, centralTenantId),
+        () -> sharingInstanceService.completePromotingLocalInstance(data));
     }
   }
 }

--- a/src/main/java/org/folio/consortia/service/KeycloakUsersService.java
+++ b/src/main/java/org/folio/consortia/service/KeycloakUsersService.java
@@ -10,4 +10,12 @@ public interface KeycloakUsersService {
    */
   void createUsersIdpLinks(String centralTenantId, String memberTenantId);
 
+  /**
+   * Remove identity provider links for users
+   *
+   * @param centralTenantId central tenant id
+   * @param memberTenantId id to of original tenant
+   */
+  void removeUsersIdpLinks(String centralTenantId, String memberTenantId);
+
 }

--- a/src/main/java/org/folio/consortia/service/UserService.java
+++ b/src/main/java/org/folio/consortia/service/UserService.java
@@ -49,6 +49,14 @@ public interface UserService {
   List<User> getPrimaryUsersToLink();
 
   /**
+   * Get primary users of valid type for linking/affiliation sync associated with tenant
+   *
+   * @param tenantId id of tenant.
+   * @return list of users.
+   */
+  List<User> getPrimaryUsersToLink(String tenantId);
+
+  /**
    * Deletes existing user by id.
    *
    * @param userId id of user.

--- a/src/main/java/org/folio/consortia/service/impl/HttpRequestServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/HttpRequestServiceImpl.java
@@ -40,9 +40,6 @@ public class HttpRequestServiceImpl implements HttpRequestService {
     HttpEntity<Object> httpEntity = new HttpEntity<>(payload, headers);
     var absUrl = folioExecutionContext.getOkapiUrl() + url;
     log.debug("performRequest:: folio context header TENANT = {}", folioExecutionContext.getOkapiHeaders().get(XOkapiHeaders.TENANT).iterator().next());
-    log.info("performRequest:: folio okapi headers = {}", folioExecutionContext.getOkapiHeaders());
-    log.info("performRequest:: all converted headers = {}", headers);
-    log.info("performRequest:: request payload = {}", objectMapper.writeValueAsString(payload));
 
     var responseEntity = switch (httpMethod.toString()) {
       case "GET", "POST", "PUT" -> restTemplate.exchange(absUrl, httpMethod, httpEntity, Object.class);

--- a/src/main/java/org/folio/consortia/service/impl/HttpRequestServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/HttpRequestServiceImpl.java
@@ -40,6 +40,9 @@ public class HttpRequestServiceImpl implements HttpRequestService {
     HttpEntity<Object> httpEntity = new HttpEntity<>(payload, headers);
     var absUrl = folioExecutionContext.getOkapiUrl() + url;
     log.debug("performRequest:: folio context header TENANT = {}", folioExecutionContext.getOkapiHeaders().get(XOkapiHeaders.TENANT).iterator().next());
+    log.info("performRequest:: folio okapi headers = {}", folioExecutionContext.getOkapiHeaders());
+    log.info("performRequest:: all converted headers = {}", headers);
+    log.info("performRequest:: request payload = {}", objectMapper.writeValueAsString(payload));
 
     var responseEntity = switch (httpMethod.toString()) {
       case "GET", "POST", "PUT" -> restTemplate.exchange(absUrl, httpMethod, httpEntity, Object.class);

--- a/src/main/java/org/folio/consortia/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package org.folio.consortia.service.impl;
 
 import static org.folio.consortia.utils.TenantContextUtils.prepareContextForTenant;
+import static org.folio.consortia.utils.TenantContextUtils.runInFolioContext;
 
 import feign.FeignException;
 
@@ -81,6 +82,11 @@ public class UserServiceImpl implements UserService {
   @Override
   public List<User> getPrimaryUsersToLink() {
     return usersClient.getUserCollection(LINKABLE_USER_QUERY, 0, Integer.MAX_VALUE).getUsers();
+  }
+
+  @Override
+  public List<User> getPrimaryUsersToLink(String tenantId) {
+    return runInFolioContext(tenantId, folioModuleMetadata, folioExecutionContext, () -> getPrimaryUsersToLink());
   }
 
   @Override

--- a/src/main/java/org/folio/consortia/utils/HelperUtils.java
+++ b/src/main/java/org/folio/consortia/utils/HelperUtils.java
@@ -18,7 +18,7 @@ public class HelperUtils {
   }
 
   public static String randomString(Integer noOfString) {
-    RandomStringGenerator generator = new RandomStringGenerator.Builder().withinRange('a', 'z').build();
+    RandomStringGenerator generator = new RandomStringGenerator.Builder().withinRange('a', 'z').get();
     return generator.generate(noOfString);
   }
 

--- a/src/main/java/org/folio/consortia/utils/HelperUtils.java
+++ b/src/main/java/org/folio/consortia/utils/HelperUtils.java
@@ -1,11 +1,15 @@
 package org.folio.consortia.utils;
 
+import java.util.UUID;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.RandomStringGenerator;
+import org.folio.consortia.domain.dto.UserTenant;
 
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
 public class HelperUtils {
-
-  private HelperUtils() {}
 
   public static void checkIdenticalOrThrow(String firstString, String secondString, String errorMsg) {
     if (!StringUtils.equals(firstString, secondString)) {
@@ -16,5 +20,15 @@ public class HelperUtils {
   public static String randomString(Integer noOfString) {
     RandomStringGenerator generator = new RandomStringGenerator.Builder().withinRange('a', 'z').build();
     return generator.generate(noOfString);
+  }
+
+  public static UserTenant createDummyUserTenant(String username, String tenantId, String centralTenantId, UUID consortiumId) {
+    return new UserTenant()
+      .id(UUID.randomUUID())
+      .userId(UUID.randomUUID())
+      .username(username)
+      .tenantId(tenantId)
+      .centralTenantId(centralTenantId)
+      .consortiumId(consortiumId);
   }
 }

--- a/src/main/java/org/folio/consortia/utils/TenantContextUtils.java
+++ b/src/main/java/org/folio/consortia/utils/TenantContextUtils.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 @UtilityClass
 @Log4j2
@@ -56,8 +57,21 @@ public class TenantContextUtils {
   }
 
   public static void runInFolioContext(FolioExecutionContext context, Runnable runnable) {
-    try (var fec = new FolioExecutionContextSetter(context)) {
+    try (var ignored = new FolioExecutionContextSetter(context)) {
       runnable.run();
+    }
+  }
+
+  public static void runInFolioContext(String tenantId, FolioModuleMetadata folioModuleMetadata, FolioExecutionContext folioExecutionContext, Runnable runnable) {
+    runInFolioContext(tenantId, folioModuleMetadata, folioExecutionContext, () -> {
+      runnable.run();
+      return null;
+    });
+  }
+
+  public static <R> R runInFolioContext(String tenantId, FolioModuleMetadata folioModuleMetadata, FolioExecutionContext folioExecutionContext, Supplier<R> supplier) {
+    try (var ignored = new FolioExecutionContextSetter(prepareContextForTenant(tenantId, folioModuleMetadata, folioExecutionContext))) {
+      return supplier.get();
     }
   }
 

--- a/src/main/resources/swagger.api/schemas/user.yaml
+++ b/src/main/resources/swagger.api/schemas/user.yaml
@@ -170,7 +170,7 @@ UserCollection:
     - users
     - totalRecords
 
-UserIdpLinkingRequest:
+UsersIdpLinkOperationRequest:
   type: object
   properties:
     userIds:

--- a/src/main/resources/swagger.api/tenants.yaml
+++ b/src/main/resources/swagger.api/tenants.yaml
@@ -216,12 +216,12 @@ components:
         application/json:
           schema:
             $ref: "schemas/tenant.yaml#/TenantDeleteRequest"
-    UserIdpLinkingRequest:
-      description: User IDP linking request object
+    UsersIdpLinkOperationRequest:
+      description: Users IDP link operation request object
       content:
         application/json:
           schema:
-            $ref: "schemas/user.yaml#/UserIdpLinkingRequest"
+            $ref: "schemas/user.yaml#/UsersIdpLinkOperationRequest"
   responses:
     Tenant:
       description: Returns a tenant object

--- a/src/test/java/org/folio/consortia/controller/TenantControllerTest.java
+++ b/src/test/java/org/folio/consortia/controller/TenantControllerTest.java
@@ -427,7 +427,7 @@ class TenantControllerTest extends BaseIT {
     String tenantId = "diku";
     var centralTenant = createTenantEntity(tenantId);
     centralTenant.setIsCentral(true);
-    var deleteRequest = createTenantDeleteRequest(TenantDeleteRequest.DeleteTypeEnum.SOFT, false);
+    var deleteRequest = createTenantDeleteRequest(TenantDeleteRequest.DeleteTypeEnum.SOFT, false, false);
     var objectMapper = new ObjectMapper();
 
     when(tenantRepository.findById(any())).thenReturn(Optional.of(centralTenant));

--- a/src/test/java/org/folio/consortia/service/KeycloakUsersServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/KeycloakUsersServiceTest.java
@@ -37,7 +37,7 @@ class KeycloakUsersServiceTest {
   void testCreateUsersIdpLinks() {
     User user = new User();
     user.setId("userId");
-    when(userService.getPrimaryUsersToLink()).thenReturn(List.of(user));
+    when(userService.getPrimaryUsersToLink(TENANT_ID)).thenReturn(List.of(user));
 
     keycloakUsersService.createUsersIdpLinks(CENTRAL_TENANT_ID, TENANT_ID);
 
@@ -46,11 +46,31 @@ class KeycloakUsersServiceTest {
 
   @Test
   void testCreateUsersIdpLinksNoUsersToLink() {
-    when(userService.getPrimaryUsersToLink()).thenReturn(Collections.emptyList());
+    when(userService.getPrimaryUsersToLink(TENANT_ID)).thenReturn(Collections.emptyList());
 
     keycloakUsersService.createUsersIdpLinks(CENTRAL_TENANT_ID, TENANT_ID);
 
     verify(usersKeycloakClient, never()).createUsersIdpLinks(any(UsersIdpLinkOperationRequest.class));
+  }
+
+  @Test
+  void testRemoveUsersIdpLinks() {
+    User user = new User();
+    user.setId("userId");
+    when(userService.getPrimaryUsersToLink(TENANT_ID)).thenReturn(List.of(user));
+
+    keycloakUsersService.removeUsersIdpLinks(CENTRAL_TENANT_ID, TENANT_ID);
+
+    verify(usersKeycloakClient).deleteUsersIdpLinks(any(UsersIdpLinkOperationRequest.class));
+  }
+
+  @Test
+  void testRemoveUsersIdpLinksNoUsersToUnlink() {
+    when(userService.getPrimaryUsersToLink(TENANT_ID)).thenReturn(Collections.emptyList());
+
+    keycloakUsersService.removeUsersIdpLinks(CENTRAL_TENANT_ID, TENANT_ID);
+
+    verify(usersKeycloakClient, never()).deleteUsersIdpLinks(any(UsersIdpLinkOperationRequest.class));
   }
 
 }

--- a/src/test/java/org/folio/consortia/service/KeycloakUsersServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/KeycloakUsersServiceTest.java
@@ -2,7 +2,6 @@ package org.folio.consortia.service;
 
 import static org.folio.consortia.support.EntityUtils.CENTRAL_TENANT_ID;
 import static org.folio.consortia.support.EntityUtils.TENANT_ID;
-import static org.folio.consortia.support.EntityUtils.getFolioExecutionContext;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -10,15 +9,13 @@ import static org.mockito.Mockito.when;
 
 import org.folio.consortia.client.UsersKeycloakClient;
 import org.folio.consortia.domain.dto.User;
-import org.folio.consortia.domain.dto.UserIdpLinkingRequest;
+import org.folio.consortia.domain.dto.UsersIdpLinkOperationRequest;
 import org.folio.consortia.service.impl.KeycloakUsersServiceImpl;
 import org.folio.consortia.support.CopilotGenerated;
-import org.folio.spring.FolioExecutionContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
@@ -32,8 +29,6 @@ class KeycloakUsersServiceTest {
   private UserService userService;
   @Mock
   private UsersKeycloakClient usersKeycloakClient;
-  @Spy
-  private FolioExecutionContext folioExecutionContext = getFolioExecutionContext();
 
   @InjectMocks
   private KeycloakUsersServiceImpl keycloakUsersService;
@@ -46,7 +41,7 @@ class KeycloakUsersServiceTest {
 
     keycloakUsersService.createUsersIdpLinks(CENTRAL_TENANT_ID, TENANT_ID);
 
-    verify(usersKeycloakClient).createUsersIdpLinks(any(UserIdpLinkingRequest.class));
+    verify(usersKeycloakClient).createUsersIdpLinks(any(UsersIdpLinkOperationRequest.class));
   }
 
   @Test
@@ -55,7 +50,7 @@ class KeycloakUsersServiceTest {
 
     keycloakUsersService.createUsersIdpLinks(CENTRAL_TENANT_ID, TENANT_ID);
 
-    verify(usersKeycloakClient, never()).createUsersIdpLinks(any(UserIdpLinkingRequest.class));
+    verify(usersKeycloakClient, never()).createUsersIdpLinks(any(UsersIdpLinkOperationRequest.class));
   }
 
 }

--- a/src/test/java/org/folio/consortia/service/TenantManagerTest.java
+++ b/src/test/java/org/folio/consortia/service/TenantManagerTest.java
@@ -98,6 +98,8 @@ class TenantManagerTest {
   @Mock
   private UserService userService;
   @Mock
+  private UserTenantService userTenantService;
+  @Mock
   private ExecutionContextBuilder executionContextBuilder;
   @Mock
   private UserTenantsClient userTenantsClient;
@@ -123,7 +125,7 @@ class TenantManagerTest {
   void setUp() {
     tenantService = new TenantServiceImpl(tenantRepository, userTenantRepository, tenantDetailsRepository, conversionService, consortiumService, folioExecutionContext);
     tenantManager = new TenantManagerImpl(tenantService, keycloakService, keycloakUsersService, consortiumService, consortiaConfigurationClient,
-      syncPrimaryAffiliationService, userService, capabilitiesUserService, customFieldService, cleanupService, lockService, userTenantsClient,
+      syncPrimaryAffiliationService, userService, userTenantService, capabilitiesUserService, customFieldService, cleanupService, lockService, userTenantsClient,
       systemUserScopedExecutionService, executionContextBuilder, folioExecutionContext);
   }
 

--- a/src/test/java/org/folio/consortia/service/TenantManagerTest.java
+++ b/src/test/java/org/folio/consortia/service/TenantManagerTest.java
@@ -3,12 +3,15 @@ package org.folio.consortia.service;
 import static org.folio.consortia.service.impl.CustomFieldServiceImpl.ORIGINAL_TENANT_ID_CUSTOM_FIELD;
 import static org.folio.consortia.support.EntityUtils.CENTRAL_TENANT_ID;
 import static org.folio.consortia.support.EntityUtils.TENANT_ID;
+import static org.folio.consortia.support.EntityUtils.TENANT_ID_1;
+import static org.folio.consortia.support.EntityUtils.TENANT_ID_2;
 import static org.folio.consortia.support.EntityUtils.createOkapiHeaders;
 import static org.folio.consortia.support.EntityUtils.createTenant;
 import static org.folio.consortia.support.EntityUtils.createTenantDeleteRequest;
 import static org.folio.consortia.support.EntityUtils.createTenantDetailsEntity;
 import static org.folio.consortia.support.EntityUtils.createTenantEntity;
 import static org.folio.consortia.support.EntityUtils.createUser;
+import static org.folio.consortia.support.EntityUtils.createUserTenantCollection;
 import static org.folio.consortia.support.EntityUtils.getFolioExecutionContext;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -298,7 +301,7 @@ class TenantManagerTest {
   void testDeleteTenantNonExistent() {
     UUID consortiumId = UUID.randomUUID();
     String tenantId = "123";
-    var deleteRequest = createTenantDeleteRequest(DeleteTypeEnum.SOFT, false);
+    var deleteRequest = createTenantDeleteRequest(DeleteTypeEnum.SOFT, false, false);
 
     // Mock repository method calls
     when(tenantRepository.existsById(tenantId)).thenReturn(false);
@@ -314,7 +317,7 @@ class TenantManagerTest {
     var tenant = createTenantEntity(TENANT_ID);
     var deletingTenant = createTenantEntity(TENANT_ID);
     deletingTenant.setIsDeleted(true);
-    var deleteRequest = createTenantDeleteRequest(DeleteTypeEnum.SOFT, true);
+    var deleteRequest = createTenantDeleteRequest(DeleteTypeEnum.SOFT, true, false);
 
     doNothing().when(consortiumService).checkConsortiumExistsOrThrow(consortiumId);
     doNothing().when(cleanupService).clearPublicationTables();
@@ -340,7 +343,7 @@ class TenantManagerTest {
     tenant.setIsCentral(true);
     var deletingTenant = createTenantEntity(TENANT_ID);
     deletingTenant.setIsDeleted(true);
-    var deleteRequest = createTenantDeleteRequest(DeleteTypeEnum.SOFT, false);
+    var deleteRequest = createTenantDeleteRequest(DeleteTypeEnum.SOFT, false, false);
 
     doNothing().when(consortiumService).checkConsortiumExistsOrThrow(consortiumId);
     when(tenantRepository.findById(tenant.getId())).thenReturn(Optional.of(tenant));
@@ -356,15 +359,29 @@ class TenantManagerTest {
   }
 
   @ParameterizedTest
-  @CsvSource({"true, false", "false, false", "true, true", "false, true"})
-  void testDeleteTenantHard(boolean deleteUserTenants, boolean isCentral) {
+  @CsvSource({"true, true, false", "false, false, false", "true, true, true", "false, false, true"})
+  void testDeleteTenantHard(boolean deleteUserTenants, boolean deleteRelatedShadowUsers, boolean isCentral) {
     UUID consortiumId = UUID.randomUUID();
     var tenant = createTenantEntity(TENANT_ID);
     tenant.setIsCentral(isCentral);
-    var deleteRequest = createTenantDeleteRequest(DeleteTypeEnum.HARD, deleteUserTenants);
+    var deleteRequest = createTenantDeleteRequest(DeleteTypeEnum.HARD, deleteUserTenants, deleteRelatedShadowUsers);
 
-    if (deleteUserTenants) {
+    var users = List.of(createUser("user1"), createUser("user2"), createUser("user3"));
+    when(userService.getPrimaryUsersToLink(TENANT_ID)).thenReturn(users);
+
+    var userTenantIds = List.of(TENANT_ID_1, TENANT_ID_2);
+    users.forEach(user ->
+      when(userTenantService.getByUserId(consortiumId, UUID.fromString(user.getId()), 0, Integer.MAX_VALUE))
+        .thenReturn(createUserTenantCollection(user.getId(), user.getUsername(), userTenantIds)));
+
+    if (deleteUserTenants && !isCentral) {
       doNothing().when(userTenantsClient).deleteUserTenants();
+    }
+    if (deleteRelatedShadowUsers) {
+      when(tenantRepository.findCentralTenant()).thenReturn(Optional.of(createTenantEntity(CENTRAL_TENANT_ID)));
+      doNothing().when(keycloakService).deleteIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
+      doNothing().when(keycloakUsersService).removeUsersIdpLinks(CENTRAL_TENANT_ID, TENANT_ID);
+      doNothing().when(userTenantsClient).deleteUserTenantsByTenantId(TENANT_ID);
     }
     doNothing().when(consortiaConfigurationClient).deleteConfiguration();
     doNothing().when(cleanupService).clearSharingTables(TENANT_ID);
@@ -372,7 +389,6 @@ class TenantManagerTest {
     doNothing().when(cleanupService).clearPublicationTables();
     doNothing().when(tenantRepository).delete(tenant);
     doNothing().when(userTenantRepository).deleteUserTenantsByTenantId(TENANT_ID);
-//    doNothing().when(keycloakService).deleteIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
     mockOkapiHeaders();
     when(tenantRepository.findById(tenant.getId())).thenReturn(Optional.of(tenant));
     when(executionContextBuilder.buildContext(anyString())).thenReturn(folioExecutionContext);
@@ -380,9 +396,18 @@ class TenantManagerTest {
 
     tenantManager.delete(consortiumId, TENANT_ID, deleteRequest);
 
-    var verifyTimes = deleteUserTenants ? times(1) : never();
-    verify(userTenantsClient, verifyTimes).deleteUserTenants();
-
+    if (deleteUserTenants && !isCentral) {
+      verify(userTenantsClient).deleteUserTenants();
+    }
+    if (deleteRelatedShadowUsers) {
+      if (!isCentral) {
+        verify(keycloakService).deleteIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
+        verify(keycloakUsersService).removeUsersIdpLinks(CENTRAL_TENANT_ID, TENANT_ID);
+      }
+      verify(userTenantService, times(users.size())).getByUserId(eq(consortiumId), any(), eq(0), eq(Integer.MAX_VALUE));
+      verify(userService, times(users.size() * userTenantIds.size())).deleteById(any());
+      verify(userTenantsClient, times(userTenantIds.size())).deleteUserTenantsByTenantId(any());
+    }
     verify(consortiaConfigurationClient).deleteConfiguration();
     verify(cleanupService).clearSharingTables(TENANT_ID);
     verify(consortiumService).checkConsortiumExistsOrThrow(consortiumId);
@@ -390,7 +415,6 @@ class TenantManagerTest {
     verify(cleanupService).clearPublicationTables();
     verify(tenantRepository).delete(tenant);
     verify(userTenantRepository).deleteUserTenantsByTenantId(TENANT_ID);
-//    verify(keycloakService).deleteIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
   }
 
   @Test

--- a/src/test/java/org/folio/consortia/service/TenantManagerTest.java
+++ b/src/test/java/org/folio/consortia/service/TenantManagerTest.java
@@ -404,9 +404,9 @@ class TenantManagerTest {
         verify(keycloakService).deleteIdentityProvider(CENTRAL_TENANT_ID, TENANT_ID);
         verify(keycloakUsersService).removeUsersIdpLinks(CENTRAL_TENANT_ID, TENANT_ID);
       }
+      verify(userTenantsClient).deleteUserTenantsByTenantId(TENANT_ID);
       verify(userTenantService, times(users.size())).getByUserId(eq(consortiumId), any(), eq(0), eq(Integer.MAX_VALUE));
       verify(userService, times(users.size() * userTenantIds.size())).deleteById(any());
-      verify(userTenantsClient, times(userTenantIds.size())).deleteUserTenantsByTenantId(any());
     }
     verify(consortiaConfigurationClient).deleteConfiguration();
     verify(cleanupService).clearSharingTables(TENANT_ID);

--- a/src/test/java/org/folio/consortia/support/EntityUtils.java
+++ b/src/test/java/org/folio/consortia/support/EntityUtils.java
@@ -19,6 +19,7 @@ import org.folio.consortia.domain.dto.TenantDeleteRequestDeleteOptions;
 import org.folio.consortia.domain.dto.TenantDetails.SetupStatusEnum;
 import org.folio.consortia.domain.dto.User;
 import org.folio.consortia.domain.dto.UserTenant;
+import org.folio.consortia.domain.dto.UserTenantCollection;
 import org.folio.consortia.domain.entity.ConsortiaConfigurationEntity;
 import org.folio.consortia.domain.entity.ConsortiumEntity;
 import org.folio.consortia.domain.entity.PublicationStatusEntity;
@@ -188,12 +189,27 @@ public class EntityUtils {
     return tenant;
   }
 
-  public static TenantDeleteRequest createTenantDeleteRequest(TenantDeleteRequest.DeleteTypeEnum deleteType, boolean deleteUserTenants) {
+  public static TenantDeleteRequest createTenantDeleteRequest(TenantDeleteRequest.DeleteTypeEnum deleteType, boolean deleteUserTenants, boolean deleteRelatedShadowUsers) {
     return new TenantDeleteRequest()
       .deleteType(deleteType)
       .deleteOptions(new TenantDeleteRequestDeleteOptions()
         .deleteUsersUserTenants(deleteUserTenants)
-        .deleteRelatedShadowUsers(false));
+        .deleteRelatedShadowUsers(deleteRelatedShadowUsers));
+  }
+
+  public static UserTenant createUserTenant(String userId, String username, String tenantId) {
+    UserTenant userTenant = new UserTenant();
+    userTenant.setId(UUID.randomUUID());
+    userTenant.setUserId(UUID.fromString(userId));
+    userTenant.setUsername(username);
+    userTenant.setTenantId(tenantId);
+    userTenant.setIsPrimary(false);
+    return userTenant;
+  }
+
+  public static UserTenantCollection createUserTenantCollection(String userId, String username, List<String> tenantIds) {
+    var userTenants =tenantIds.stream().map(tenantId -> createUserTenant(userId, username, tenantId)).toList();
+    return new UserTenantCollection(userTenants, userTenants.size());
   }
 
   public static UserTenant createUserTenant(UUID associationId) {

--- a/src/test/java/org/folio/consortia/utils/HelperUtilsTest.java
+++ b/src/test/java/org/folio/consortia/utils/HelperUtilsTest.java
@@ -10,7 +10,7 @@ import org.folio.consortia.support.CopilotGenerated;
 import org.junit.jupiter.api.Test;
 
 @CopilotGenerated
-public class HelperUtilsTest {
+class HelperUtilsTest {
 
   @Test
   void checkIdenticalOrThrow_IdenticalStrings_NoExceptionThrown() {

--- a/src/test/java/org/folio/consortia/utils/HelperUtilsTest.java
+++ b/src/test/java/org/folio/consortia/utils/HelperUtilsTest.java
@@ -1,0 +1,52 @@
+package org.folio.consortia.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.UUID;
+
+import org.folio.consortia.domain.dto.UserTenant;
+import org.folio.consortia.support.CopilotGenerated;
+import org.junit.jupiter.api.Test;
+
+@CopilotGenerated
+public class HelperUtilsTest {
+
+  @Test
+  void checkIdenticalOrThrow_IdenticalStrings_NoExceptionThrown() {
+    HelperUtils.checkIdenticalOrThrow("test", "test", "Strings are not identical");
+  }
+
+  @Test
+  void checkIdenticalOrThrow_DifferentStrings_ExceptionThrown() {
+    assertThrows(IllegalArgumentException.class, () ->
+      HelperUtils.checkIdenticalOrThrow("test", "different", "Strings are not identical"));
+  }
+
+  @Test
+  void randomString_GeneratesStringOfCorrectLength() {
+    String randomStr = HelperUtils.randomString(10);
+    assertEquals(10, randomStr.length());
+  }
+
+  @Test
+  void randomString_GeneratesEmptyStringForZeroLength() {
+    String randomStr = HelperUtils.randomString(0);
+    assertEquals(0, randomStr.length());
+  }
+
+  @Test
+  void createDummyUserTenant_CreatesUserTenantWithCorrectValues() {
+    String username = "user";
+    String tenantId = "tenant";
+    String centralTenantId = "centralTenant";
+    UUID consortiumId = UUID.randomUUID();
+
+    UserTenant userTenant = HelperUtils.createDummyUserTenant(username, tenantId, centralTenantId, consortiumId);
+
+    assertEquals(username, userTenant.getUsername());
+    assertEquals(tenantId, userTenant.getTenantId());
+    assertEquals(centralTenantId, userTenant.getCentralTenantId());
+    assertEquals(consortiumId, userTenant.getConsortiumId());
+  }
+}

--- a/src/test/java/org/folio/consortia/utils/TenantContextUtilsTest.java
+++ b/src/test/java/org/folio/consortia/utils/TenantContextUtilsTest.java
@@ -1,10 +1,13 @@
 package org.folio.consortia.utils;
 
+import static org.folio.consortia.support.EntityUtils.getFolioExecutionContext;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -12,7 +15,10 @@ import java.util.List;
 import java.util.Map;
 
 import java.util.Objects;
+import java.util.function.Supplier;
+
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.folio.consortia.support.CopilotGenerated;
 import org.folio.spring.DefaultFolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.integration.XOkapiHeaders;
@@ -21,6 +27,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.messaging.MessageHeaders;
 
+@CopilotGenerated(partiallyGenerated = true)
 class TenantContextUtilsTest {
   private static final String TENANT_ID = "mobius";
   private FolioModuleMetadata folioModuleMetadata;
@@ -93,5 +100,37 @@ class TenantContextUtilsTest {
       Objects.requireNonNull(null, "Tenant ID cannot be null");
       TenantContextUtils.getFolioExecutionContextCopyForTenant(context, nullTenant);
     });
+  }
+
+  @Test
+  void runInFolioContext_ExecutesRunnable() {
+    var context = new DefaultFolioExecutionContext(null, new HashMap<>());
+    Runnable runnable = mock(Runnable.class);
+
+    TenantContextUtils.runInFolioContext(context, runnable);
+
+    verify(runnable).run();
+  }
+
+  @Test
+  void runInFolioContextWithTenantId_ExecutesRunnable() {
+    var context = getFolioExecutionContext();
+    Runnable runnable = mock(Runnable.class);
+
+    TenantContextUtils.runInFolioContext(TENANT_ID, context.getFolioModuleMetadata(), context, runnable);
+
+    verify(runnable).run();
+  }
+
+  @Test
+  void runInFolioContextWithTenantIdAndSupplier_ReturnsSupplierResult() {
+    var context = getFolioExecutionContext();
+    Supplier<String> supplier = mock(Supplier.class);
+    when(supplier.get()).thenReturn("result");
+
+    String result = TenantContextUtils.runInFolioContext(TENANT_ID, context.getFolioModuleMetadata(), context, supplier);
+
+    assertEquals("result", result);
+    verify(supplier).get();
   }
 }


### PR DESCRIPTION
## Purpose
[[MODCONSKC-69] Add support for deleting related module's data for consortia tenant hard delete](https://folio-org.atlassian.net/browse/MODCONSKC-69)

## Approach
- Simplify context switching
- Update IDP link request
- Add user IDP link removal
- Add shadow user and IDP data deletion during tenant hard delete
- Update tests