### PR TITLE
[MODCONSKC-73] Implement possibility for user to login with updated username

### DIFF
--- a/src/main/java/org/folio/consortia/service/KeycloakUsersService.java
+++ b/src/main/java/org/folio/consortia/service/KeycloakUsersService.java
@@ -18,4 +18,12 @@ public interface KeycloakUsersService {
    */
   void removeUsersIdpLinks(String centralTenantId, String memberTenantId);
 
+  /**
+   * Recreate identity provider link for a user
+   *
+   * @param centralTenantId central tenant id
+   * @param userId user id
+   */
+  void recreateUserIdpLink(String centralTenantId, String userId);
+
 }

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakUsersServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakUsersServiceImpl.java
@@ -1,5 +1,6 @@
 package org.folio.consortia.service.impl;
 
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -32,6 +33,13 @@ public class KeycloakUsersServiceImpl implements KeycloakUsersService {
   public void removeUsersIdpLinks(String centralTenantId, String memberTenantId) {
     log.info("removeUsersIdpLinks:: Removing IDP links for users from original member tenant: '{}' in central tenant: '{}'", memberTenantId, centralTenantId);
     applyUsersIdpLinkOperation(centralTenantId, memberTenantId, usersKeycloakClient::deleteUsersIdpLinks);
+  }
+
+  @Override
+  public void recreateUserIdpLink(String centralTenantId, String userId) {
+    log.info("recreateUserIdpLink:: Recreating IDP link for user: '{}' in central tenant: '{}'", userId, centralTenantId);
+    var request = new UsersIdpLinkOperationRequest().userIds(Set.of(userId)).centralTenantId(centralTenantId);
+    usersKeycloakClient.createUsersIdpLinks(request);
   }
 
   private void applyUsersIdpLinkOperation(String centralTenantId, String memberTenantId, Consumer<UsersIdpLinkOperationRequest> linkOperation) {

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakUsersServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakUsersServiceImpl.java
@@ -38,8 +38,7 @@ public class KeycloakUsersServiceImpl implements KeycloakUsersService {
   @Override
   public void recreateUserIdpLink(String centralTenantId, String userId) {
     log.info("recreateUserIdpLink:: Recreating IDP link for user: '{}' in central tenant: '{}'", userId, centralTenantId);
-    var request = new UsersIdpLinkOperationRequest().userIds(Set.of(userId)).centralTenantId(centralTenantId);
-    usersKeycloakClient.createUsersIdpLinks(request);
+    usersKeycloakClient.createUsersIdpLinks(new UsersIdpLinkOperationRequest(Set.of(userId), centralTenantId));
   }
 
   private void applyUsersIdpLinkOperation(String centralTenantId, String memberTenantId, Consumer<UsersIdpLinkOperationRequest> linkOperation) {

--- a/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
@@ -105,10 +105,9 @@ public class UserAffiliationServiceImpl implements UserAffiliationService {
 
       if (isUsernameChanged) {
         userTenantService.updateUsernameInPrimaryUserTenantAffiliation(userId, newUsername, userEvent.getTenantId());
-        log.info("updatePrimaryUserAffiliation:: Username in primary affiliation has been updated for the user: {}", userEvent.getUserDto().getId());
       }
 
-      if (Boolean.TRUE.equals(userEvent.getIsPersonalDataChanged())) {
+      if (isUsernameChanged || Boolean.TRUE.equals(userEvent.getIsPersonalDataChanged())) {
         userTenantService.updateShadowUsersNameAndEmail(getUserId(userEvent), userEvent.getTenantId());
       }
       PrimaryAffiliationEvent affiliationEvent = createPrimaryAffiliationEvent(userEvent, centralTenantId, null);

--- a/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
@@ -12,6 +12,7 @@ import org.folio.consortia.domain.dto.User;
 import org.folio.consortia.domain.dto.UserEvent;
 import org.folio.consortia.domain.dto.UserType;
 import org.folio.consortia.domain.entity.UserTenantEntity;
+import org.folio.consortia.service.KeycloakUsersService;
 import org.folio.consortia.service.PrimaryAffiliationService;
 import org.folio.consortia.service.TenantService;
 import org.folio.consortia.service.UserAffiliationService;
@@ -35,6 +36,7 @@ public class UserAffiliationServiceImpl implements UserAffiliationService {
   private final UserTenantService userTenantService;
   private final TenantService tenantService;
   private final KafkaService kafkaService;
+  private final KeycloakUsersService keycloakUsersService;
   private final FolioExecutionContext folioExecutionContext;
   private final PrimaryAffiliationService primaryAffiliationService;
   private final ObjectMapper objectMapper = new ObjectMapper();
@@ -105,6 +107,7 @@ public class UserAffiliationServiceImpl implements UserAffiliationService {
 
       if (isUsernameChanged) {
         userTenantService.updateUsernameInPrimaryUserTenantAffiliation(userId, newUsername, userEvent.getTenantId());
+        keycloakUsersService.recreateUserIdpLink(userId.toString(), centralTenantId);
       }
 
       if (isUsernameChanged || Boolean.TRUE.equals(userEvent.getIsPersonalDataChanged())) {

--- a/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
@@ -105,14 +105,15 @@ public class UserAffiliationServiceImpl implements UserAffiliationService {
       UserTenantEntity userTenant = userTenantService.getByUserIdAndTenantId(userId, userEvent.getTenantId());
       boolean isUsernameChanged = ObjectUtils.notEqual(userTenant.getUsername(), newUsername);
 
+      if (isUsernameChanged || Boolean.TRUE.equals(userEvent.getIsPersonalDataChanged())) {
+        userTenantService.updateShadowUsersNameAndEmail(getUserId(userEvent), userEvent.getTenantId());
+      }
+
       if (isUsernameChanged) {
         userTenantService.updateUsernameInPrimaryUserTenantAffiliation(userId, newUsername, userEvent.getTenantId());
         keycloakUsersService.recreateUserIdpLink(centralTenantId, userId.toString());
       }
 
-      if (isUsernameChanged || Boolean.TRUE.equals(userEvent.getIsPersonalDataChanged())) {
-        userTenantService.updateShadowUsersNameAndEmail(getUserId(userEvent), userEvent.getTenantId());
-      }
       PrimaryAffiliationEvent affiliationEvent = createPrimaryAffiliationEvent(userEvent, centralTenantId, null);
       String data = objectMapper.writeValueAsString(affiliationEvent);
 

--- a/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/UserAffiliationServiceImpl.java
@@ -107,7 +107,7 @@ public class UserAffiliationServiceImpl implements UserAffiliationService {
 
       if (isUsernameChanged) {
         userTenantService.updateUsernameInPrimaryUserTenantAffiliation(userId, newUsername, userEvent.getTenantId());
-        keycloakUsersService.recreateUserIdpLink(userId.toString(), centralTenantId);
+        keycloakUsersService.recreateUserIdpLink(centralTenantId, userId.toString());
       }
 
       if (isUsernameChanged || Boolean.TRUE.equals(userEvent.getIsPersonalDataChanged())) {

--- a/src/main/java/org/folio/consortia/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/UserServiceImpl.java
@@ -41,7 +41,6 @@ public class UserServiceImpl implements UserService {
   private final UsersClient usersClient;
   private final FolioExecutionContext folioExecutionContext;
   private final FolioModuleMetadata folioModuleMetadata;
-  private static final Integer RANDOM_STRING_COUNT = 5;
   private static final String ORIGINAL_TENANT_ID_REF_ID = "originaltenantid";
 
   @Override
@@ -112,7 +111,7 @@ public class UserServiceImpl implements UserService {
 
       var shadowUser = new User();
       shadowUser.setId(userId.toString());
-      shadowUser.setUsername(String.format("%s_%s", realUser.getUsername(), HelperUtils.randomString(RANDOM_STRING_COUNT)));
+      shadowUser.setUsername(HelperUtils.generateShadowUsername(realUser.getUsername()));
       shadowUser.setType(UserType.SHADOW.getName());
       shadowUser.setActive(true);
 

--- a/src/main/java/org/folio/consortia/service/impl/UserTenantServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/UserTenantServiceImpl.java
@@ -235,7 +235,7 @@ public class UserTenantServiceImpl implements UserTenantService {
         try (var ignored = new FolioExecutionContextSetter(
           TenantContextUtils.prepareContextForTenant(tenantId, folioModuleMetadata, folioExecutionContext))) {
           User shadowUser = userService.getById(userId);
-          shadowUser.setUsername(HelperUtils.generateShadowUsername(username));
+          shadowUser.setUsername(HelperUtils.generateShadowUsernameOrDefault(username, shadowUser.getUsername()));
           shadowUser.getPersonal().setFirstName(firstName);
           shadowUser.getPersonal().setLastName(lastName);
           shadowUser.getPersonal().setEmail(email);

--- a/src/main/java/org/folio/consortia/utils/HelperUtils.java
+++ b/src/main/java/org/folio/consortia/utils/HelperUtils.java
@@ -11,15 +11,17 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class HelperUtils {
 
+  private static final Integer RANDOM_STRING_COUNT = 5;
+
   public static void checkIdenticalOrThrow(String firstString, String secondString, String errorMsg) {
     if (!StringUtils.equals(firstString, secondString)) {
       throw new IllegalArgumentException(errorMsg);
     }
   }
 
-  public static String randomString(Integer noOfString) {
+  public static String generateShadowUsername(String realUsername) {
     RandomStringGenerator generator = new RandomStringGenerator.Builder().withinRange('a', 'z').get();
-    return generator.generate(noOfString);
+    return "%s_%s".formatted(realUsername, generator.generate(RANDOM_STRING_COUNT));
   }
 
   public static UserTenant createDummyUserTenant(String username, String tenantId, String centralTenantId, UUID consortiumId) {

--- a/src/main/java/org/folio/consortia/utils/HelperUtils.java
+++ b/src/main/java/org/folio/consortia/utils/HelperUtils.java
@@ -24,6 +24,13 @@ public class HelperUtils {
     return "%s_%s".formatted(realUsername, generator.generate(RANDOM_STRING_COUNT));
   }
 
+  public static String generateShadowUsernameOrDefault(String realUsername, String shadowUsername) {
+    var shadowUsernameOriginal = shadowUsername.substring(0, shadowUsername.length() - RANDOM_STRING_COUNT - 1);
+    return shadowUsernameOriginal.equals(realUsername)
+      ? shadowUsername
+      : generateShadowUsername(realUsername);
+  }
+
   public static UserTenant createDummyUserTenant(String username, String tenantId, String centralTenantId, UUID consortiumId) {
     return new UserTenant()
       .id(UUID.randomUUID())

--- a/src/test/java/org/folio/consortia/service/KeycloakUsersServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/KeycloakUsersServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Collections;
+import java.util.Set;
 
 @ExtendWith(MockitoExtension.class)
 @CopilotGenerated
@@ -71,6 +72,15 @@ class KeycloakUsersServiceTest {
     keycloakUsersService.removeUsersIdpLinks(CENTRAL_TENANT_ID, TENANT_ID);
 
     verify(usersKeycloakClient, never()).deleteUsersIdpLinks(any(UsersIdpLinkOperationRequest.class));
+  }
+
+  @Test
+  void testRecreateUserIdpLink() {
+    var userIdpLinkOperationRequest = new UsersIdpLinkOperationRequest(Set.of("userId"), CENTRAL_TENANT_ID);
+
+    keycloakUsersService.recreateUserIdpLink(CENTRAL_TENANT_ID, "userId");
+
+    verify(usersKeycloakClient).createUsersIdpLinks(userIdpLinkOperationRequest);
   }
 
 }

--- a/src/test/java/org/folio/consortia/service/UserAffiliationServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/UserAffiliationServiceTest.java
@@ -51,6 +51,8 @@ class UserAffiliationServiceTest {
   @Mock
   KafkaService kafkaService;
   @Mock
+  KeycloakUsersService keycloakUsersService;
+  @Mock
   PrimaryAffiliationService primaryAffiliationService;
   @Mock
   FolioExecutionContext folioExecutionContext;

--- a/src/test/java/org/folio/consortia/service/UserTenantServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/UserTenantServiceTest.java
@@ -193,15 +193,12 @@ class UserTenantServiceTest {
   void shouldUpdateEmailAndName() {
     UUID userId = USER_ID;
     String tenantId = "diku";
-    UUID associationId = UUID.randomUUID();
     User primaryUser = createUserEntity(userId);
     User shadowUser = createUserEntity(userId);
     shadowUser.getPersonal().setFirstName("notUpdatedFirstName");
     shadowUser.getPersonal().setFirstName("notUpdatedLastName");
     shadowUser.getPersonal().setEmail("notUpdatedEmail");
-    User updatedShadowUser = createUserEntity(userId);
-    updatedShadowUser.setUsername(HelperUtils.generateShadowUsername(primaryUser.getUsername()));
-    UserTenantEntity userTenant = createUserTenantEntity(associationId, userId, "user", "shadowTenantId");
+    UserTenantEntity userTenant = createUserTenantEntity(UUID.randomUUID(), userId, "user", "shadowTenantId");
     userTenant.setIsPrimary(false);
 
     // validation part
@@ -211,11 +208,11 @@ class UserTenantServiceTest {
     when(userTenantRepository.getByUserIdAndIsPrimaryFalse(userId)).thenReturn(List.of(userTenant));
     // In first call it return primary User, in second call it return shadow user.
     when(userService.getById(userId)).thenReturn(primaryUser).thenReturn(shadowUser);
-    doNothing().when(userService).updateUser(updatedShadowUser);
+    doNothing().when(userService).updateUser(shadowUser);
     userTenantService.updateShadowUsersNameAndEmail(userId, tenantId);
 
     verify(userService, times(2)).getById(userId);
-    verify(userService, times(1)).updateUser(updatedShadowUser);
+    verify(userService, times(1)).updateUser(shadowUser);
   }
 
   @Test

--- a/src/test/java/org/folio/consortia/service/UserTenantServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/UserTenantServiceTest.java
@@ -190,16 +190,17 @@ class UserTenantServiceTest {
   }
 
   @Test
-  void shouldUpdateEmailAndName() {
+  void testUpdateShadowUsersNameAndEmail() {
     UUID userId = USER_ID;
     String tenantId = "diku";
     User primaryUser = createUserEntity(userId);
+    primaryUser.setUsername("testuser");
     User shadowUser = createUserEntity(userId);
     shadowUser.setUsername(HelperUtils.generateShadowUsername(primaryUser.getUsername()));
     shadowUser.getPersonal().setFirstName("notUpdatedFirstName");
     shadowUser.getPersonal().setFirstName("notUpdatedLastName");
     shadowUser.getPersonal().setEmail("notUpdatedEmail");
-    UserTenantEntity userTenant = createUserTenantEntity(UUID.randomUUID(), userId, "user", "shadowTenantId");
+    UserTenantEntity userTenant = createUserTenantEntity(UUID.randomUUID(), userId, primaryUser.getUsername(), "shadowTenantId");
     userTenant.setIsPrimary(false);
 
     // validation part

--- a/src/test/java/org/folio/consortia/service/UserTenantServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/UserTenantServiceTest.java
@@ -195,6 +195,7 @@ class UserTenantServiceTest {
     String tenantId = "diku";
     User primaryUser = createUserEntity(userId);
     User shadowUser = createUserEntity(userId);
+    shadowUser.setUsername(HelperUtils.generateShadowUsername(primaryUser.getUsername()));
     shadowUser.getPersonal().setFirstName("notUpdatedFirstName");
     shadowUser.getPersonal().setFirstName("notUpdatedLastName");
     shadowUser.getPersonal().setEmail("notUpdatedEmail");

--- a/src/test/java/org/folio/consortia/service/UserTenantServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/UserTenantServiceTest.java
@@ -37,6 +37,7 @@ import org.folio.consortia.exception.ResourceNotFoundException;
 import org.folio.consortia.exception.UserAffiliationException;
 import org.folio.consortia.repository.UserTenantRepository;
 import org.folio.consortia.service.impl.UserTenantServiceImpl;
+import org.folio.consortia.utils.HelperUtils;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.data.OffsetRequest;
@@ -199,6 +200,7 @@ class UserTenantServiceTest {
     shadowUser.getPersonal().setFirstName("notUpdatedLastName");
     shadowUser.getPersonal().setEmail("notUpdatedEmail");
     User updatedShadowUser = createUserEntity(userId);
+    updatedShadowUser.setUsername(HelperUtils.generateShadowUsername(primaryUser.getUsername()));
     UserTenantEntity userTenant = createUserTenantEntity(associationId, userId, "user", "shadowTenantId");
     userTenant.setIsPrimary(false);
 

--- a/src/test/java/org/folio/consortia/utils/HelperUtilsTest.java
+++ b/src/test/java/org/folio/consortia/utils/HelperUtilsTest.java
@@ -2,6 +2,7 @@ package org.folio.consortia.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.UUID;
 
@@ -24,15 +25,10 @@ class HelperUtilsTest {
   }
 
   @Test
-  void randomString_GeneratesStringOfCorrectLength() {
-    String randomStr = HelperUtils.randomString(10);
-    assertEquals(10, randomStr.length());
-  }
-
-  @Test
-  void randomString_GeneratesEmptyStringForZeroLength() {
-    String randomStr = HelperUtils.randomString(0);
-    assertEquals(0, randomStr.length());
+  void generateShadowUsername_GeneratesCorrectString() {
+    String randomStr = HelperUtils.generateShadowUsername("username");
+    assertEquals(14, randomStr.length());
+    assertTrue(randomStr.matches("username_[a-z]{5}"));
   }
 
   @Test

--- a/src/test/java/org/folio/consortia/utils/HelperUtilsTest.java
+++ b/src/test/java/org/folio/consortia/utils/HelperUtilsTest.java
@@ -1,6 +1,7 @@
 package org.folio.consortia.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,6 +30,27 @@ class HelperUtilsTest {
     String randomStr = HelperUtils.generateShadowUsername("username");
     assertEquals(14, randomStr.length());
     assertTrue(randomStr.matches("username_[a-z]{5}"));
+  }
+
+  @Test
+  void generateShadowUsernameOrDefault_ShouldReturnExistingShadowUsername() {
+    String realUsername = "username";
+    String existingShadowUsername = "username_abcde";
+
+    String newShadowUsername = HelperUtils.generateShadowUsernameOrDefault(realUsername, existingShadowUsername);
+
+    assertEquals(existingShadowUsername, newShadowUsername);
+  }
+
+  @Test
+  void generateShadowUsernameOrDefault_ShouldGenerateNewShadowUsernameWhenOriginalChanged() {
+    String realUsername = "newusername";
+    String oldShadowUsername = "oldusername_abcde";
+
+    String newShadowUsername = HelperUtils.generateShadowUsernameOrDefault(realUsername, oldShadowUsername);
+
+    assertNotEquals(oldShadowUsername, newShadowUsername);
+    assertTrue(newShadowUsername.matches("newusername_[a-z]{5}"));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
[[MODCONSKC-73] Implement possibility for user to login with updated username](https://folio-org.atlassian.net/browse/MODCONSKC-73)

## Approach
- If username was changed, update shadow users with new usernames
- If username was changed, recreate IDP link for the user to contain up-to-date username
- Add and update new tests