### PR TITLE
MODCONSKC-79 - Add permission to restrict update of instance and its MARC located on central tenant

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 ## 1.8.0 - Unreleased
 
+### Stories
+* [MODCONSKC-79](https://folio-org.atlassian.net/browse/MODCONSKC-79) - Add permission to restrict update of instance and its MARC on central tenant
+
+
 ## 1.7.0 - Released (Sunflower R1 2025)
 The purpose of this release is to implement sharing features and fixing module permissions
 [Full Changelog](https://github.com/folio-org/mod-consortia/compare/v1.6.0...v1.7.0)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -911,6 +911,12 @@
       "permissionName": "consortia.sharing-roles-capabilities.item.delete",
       "displayName": "delete sharing role capabilities",
       "description": "Delete sharing role capabilities"
+    },
+    {
+      "permissionName": "consortia.data-import.central-record-update.execute",
+      "displayName": "Data Import - update shared record",
+      "description": "Update shared instance and MARC record",
+      "visible": true
     }
   ],
   "metadata": {


### PR DESCRIPTION
## Purpose
to restrict data import update action from a member tenant for a record and instance located on a central tenant

## Approach
* add permission that will allow update of shared instance/record through data import


## Learning
[MODCONSKC-79](https://issues.folio.org/browse/MODCONSKC-79)
