### PR TITLE
MODCONSKC-82. The local instance is not shared

### DIFF
--- a/src/main/java/org/folio/consortia/service/impl/SharingInstanceServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/SharingInstanceServiceImpl.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import jakarta.transaction.Transactional;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;

--- a/src/main/java/org/folio/consortia/service/impl/SharingInstanceServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/SharingInstanceServiceImpl.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import jakarta.transaction.Transactional;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
@@ -68,6 +69,9 @@ public class SharingInstanceServiceImpl implements SharingInstanceService {
     String centralTenantId = tenantService.getCentralTenantId();
     String sourceTenantId = sharingInstance.getSourceTenantId();
     String targetTenantId = sharingInstance.getTargetTenantId();
+    if (Objects.isNull(sharingInstance.getId())) {
+      sharingInstance.setId(UUID.randomUUID());
+    }
     checkTenantsExistAndContainCentralTenantOrThrow(sourceTenantId, targetTenantId);
 
     if (Objects.equals(centralTenantId, sourceTenantId)) {
@@ -215,7 +219,7 @@ public class SharingInstanceServiceImpl implements SharingInstanceService {
 
   private SharingInstanceEntity toEntity(SharingInstance dto) {
     SharingInstanceEntity entity = new SharingInstanceEntity();
-    entity.setId(UUID.randomUUID());
+    entity.setId(dto.getId());
     entity.setInstanceId(dto.getInstanceIdentifier());
     entity.setSourceTenantId(dto.getSourceTenantId());
     entity.setTargetTenantId(dto.getTargetTenantId());


### PR DESCRIPTION
### **Purpose**
https://folio-org.atlassian.net/browse/MODCONSKC-82

### **Approach**
The root cause is that the ui-inventory no longer populates the id property when sharing an instance, and the id is used as the Kafka key. 

<img width="1236" height="562" alt="image" src="https://github.com/user-attachments/assets/b3066b71-5954-49f7-bfe0-de05e017c1cd" />

One possible solution is to modify ui-inventory to provide a random UUID or use mod-consortia-keycloak to generate a random UUID in case it is missing from the request.

The second option was chosen because it is more reliable.

---

### **Pre-Review Checklist**

- [ ] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [ ] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
