### PR TITLE
MODCONSKC-86 - Use SECURE_STORE_ENV, not ENV, for secure store key

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ### Stories
 * [MODCONSKC-79](https://folio-org.atlassian.net/browse/MODCONSKC-79) - Add permission to restrict update of instance and its MARC on central tenant
-
+* [MODCONSKC-86](https://folio-org.atlassian.net/browse/MODCONSKC-86) - Use SECURE_STORE_ENV, not ENV, for secure store key
 
 ## 1.7.0 - Released (Sunflower R1 2025)
 The purpose of this release is to implement sharing features and fixing module permissions

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ requires and provides, the permissions, and the additional module metadata.
 
 ### Secure storage environment variables
 
+| Name                | Default value | Description                                                                                                                                                    |
+|:--------------------|:--------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SECURE_STORE_ENV    | folio         | First segment of the secure store key, for example `prod` or `test`. Defaults to `folio`. In Ramsons and Sunflower defaults to ENV with fall-back `folio`.     |
+
 #### AWS-SSM
 
 Required when `SECRET_STORE_TYPE=AWS_SSM`

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <folio-module-descriptor-validator.version>1.0.1</folio-module-descriptor-validator.version>
     <folio-spring-base.version>10.0.0-SNAPSHOT</folio-spring-base.version>
     <folio-service-tools.version>5.0.0</folio-service-tools.version>
-    <applications-poc-tools.version>3.0.2</applications-poc-tools.version>
+    <applications-poc-tools.version>3.1.0-SNAPSHOT</applications-poc-tools.version>
 
     <!-- runtime dependencies -->
     <openapi-generator.version>7.14.0</openapi-generator.version>

--- a/src/main/java/org/folio/consortia/service/impl/KeycloakCredentialsServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/KeycloakCredentialsServiceImpl.java
@@ -10,8 +10,8 @@ import org.folio.consortia.config.keycloak.KeycloakProperties;
 import org.folio.consortia.domain.dto.KeycloakClientCredentials;
 import org.folio.consortia.service.KeycloakCredentialsService;
 import org.folio.tools.store.SecureStore;
-import org.folio.tools.store.exception.NotFoundException;
-import org.springframework.beans.factory.annotation.Value;
+import org.folio.tools.store.exception.SecretNotFoundException;
+import org.folio.tools.store.properties.SecureStoreProperties;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -28,9 +28,7 @@ public class KeycloakCredentialsServiceImpl implements KeycloakCredentialsServic
   private final KeycloakProperties keycloakProperties;
   private final KeycloakLoginClientProperties keycloakClientProperties;
   private final SecureStore secureStore;
-
-  @Value("${folio.environment}")
-  private String folioEnvironment;
+  private final SecureStoreProperties secureStoreProperties;
 
   public KeycloakClientCredentials getClientCredentials(String tenantId, String token) {
     var clientId = tenantId + keycloakClientProperties.getClientNameSuffix();
@@ -59,8 +57,8 @@ public class KeycloakCredentialsServiceImpl implements KeycloakCredentialsServic
   private String getBackendAdminClientSecret(String clientId) {
     try {
       log.info("getBackendAdminClientSecret:: Retrieving backend admin client secret from secure store");
-      return secureStore.get("%s_%s_%s".formatted(folioEnvironment, MASTER_REALM, clientId));
-    } catch (NotFoundException e) {
+      return secureStore.get("%s_%s_%s".formatted(secureStoreProperties.getEnvironment(), MASTER_REALM, clientId));
+    } catch (SecretNotFoundException e) {
       log.error("getBackendAdminClientSecret:: Backend admin client secret not found in secure store for clientId: {}", clientId);
       throw new IllegalStateException("Failed to get value from secure store [clientId: %s]".formatted(clientId), e);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,6 +78,7 @@ folio:
   max-active-threads: 5
 application:
   secret-store:
+    environment: ${SECURE_STORE_ENV:${ENV:folio}}
     type: ${SECRET_STORE_TYPE:EPHEMERAL}
     aws-ssm:
       region: ${SECRET_STORE_AWS_SSM_REGION:}

--- a/src/test/java/org/folio/consortia/service/KeycloakCredentialsServiceTest.java
+++ b/src/test/java/org/folio/consortia/service/KeycloakCredentialsServiceTest.java
@@ -11,14 +11,14 @@ import org.folio.consortia.domain.dto.KeycloakTokenResponse;
 import org.folio.consortia.service.impl.KeycloakCredentialsServiceImpl;
 import org.folio.consortia.support.CopilotGenerated;
 import org.folio.tools.store.SecureStore;
-import org.folio.tools.store.exception.NotFoundException;
+import org.folio.tools.store.exception.SecretNotFoundException;
+import org.folio.tools.store.properties.SecureStoreProperties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.util.List;
 
@@ -36,13 +36,12 @@ class KeycloakCredentialsServiceTest {
   private KeycloakLoginClientProperties keycloakClientProperties;
   @Mock
   private SecureStore secureStore;
+  @Mock
+  private SecureStoreProperties secureStoreProperties;
 
   @InjectMocks
   @Spy
   private KeycloakCredentialsServiceImpl keycloakCredentialsService;
-
-  @Value("${folio.environment}")
-  private String folioEnvironment;
 
   @Test
   void getClientCredentials_returnsValidCredentials() {
@@ -84,26 +83,30 @@ class KeycloakCredentialsServiceTest {
   void getMasterAuthToken_returnsValidToken() {
     String clientId = "clientId";
     String clientSecret = "clientSecret";
+    var secureStoreEnv = "folio";
     var tokenResponse = createTokenResponse();
 
     when(keycloakProperties.getClientId()).thenReturn(clientId);
     when(secureStore.get(anyString())).thenReturn(clientSecret);
     when(keycloakClient.login(anyMap())).thenReturn(tokenResponse);
+    when(secureStoreProperties.getEnvironment()).thenReturn(secureStoreEnv);
 
     String token = keycloakCredentialsService.getMasterAuthToken();
 
     assertEquals(AUTH_TOKEN, token);
-    verify(secureStore).get("%s_%s_%s".formatted(folioEnvironment, "master", clientId));
+    verify(secureStore).get("%s_%s_%s".formatted(secureStoreEnv, "master", clientId));
   }
 
   @Test
   void getMasterAuthToken_throwsException_secretNotFound() {
     String clientId = "clientId";
+    var secureStoreEnv = "folio";
     when(keycloakProperties.getClientId()).thenReturn(clientId);
-    when(secureStore.get(anyString())).thenThrow(new NotFoundException("Not found"));
+    when(secureStore.get(anyString())).thenThrow(new SecretNotFoundException("Not found"));
+    when(secureStoreProperties.getEnvironment()).thenReturn(secureStoreEnv);
 
     assertThrows(IllegalStateException.class, () -> keycloakCredentialsService.getMasterAuthToken());
-    verify(secureStore).get("%s_%s_%s".formatted(folioEnvironment, "master", clientId));
+    verify(secureStore).get("%s_%s_%s".formatted(secureStoreEnv, "master", clientId));
   }
 
   private static KeycloakTokenResponse createTokenResponse() {


### PR DESCRIPTION
### **Purpose**
[MODCONSKC-86](https://folio-org.atlassian.net/browse/MODCONSKC-86) - Use SECURE_STORE_ENV, not ENV, for secure store key

### **Approach**

Use the SECURE_STORE_ENV environment variable, not the ENV environment variable, as the first component of the secure store key.

---

### **Pre-Review Checklist**

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [x] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Logging**: Confirmed that logging is appropriately handled.
- [ ] **Breaking Changes** — Handled all required actions if changes affect API, DB, or interface versions.
  - [ ] API/schema changes
  - [ ] Interface version updates
  - [ ] DB schema changes / migration scripts
- [x] **New Properties / Environment Variables** — Updated README.md if new configs were added.
