### PR TITLE
Trillium release v1.8.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+## 1.8.1 - Released (Trillium R1 2025)
+The purpose of this release is to add possibility to enable http request logging.
+[Full Changelog](https://github.com/folio-org/mod-consortia-keycloak/compare/v1.8.0...v1.8.1)
+
+### Stories
+* [MODCONSKC-117](https://folio-org.atlassian.net/browse/MODCONSKC-117) - HTTP requests logging configuration
+
 ## 1.8.0 - Released (Trillium R1 2025)
 The purpose of this release is to upgrade to SpringBoot 4.0 / Spring 7.0, add general exception handling, and fix various issues.
 [Full Changelog](https://github.com/folio-org/mod-consortia-keycloak/compare/v1.7.0...v1.8.0)

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <groupId>org.folio</groupId>
   <artifactId>mod-consortia-keycloak</artifactId>
   <name>mod-consortia-keycloak</name>
-  <version>1.8.1</version>
+  <version>1.8.2-SNAPSHOT</version>
   <description>Business logic to manage consortia in FOLIO</description>
   <packaging>jar</packaging>
 
@@ -760,7 +760,7 @@
     <url>https://github.com/folio-org/mod-consortia-keycloak</url>
     <connection>scm:git:git://github.com:folio-org/mod-consortia-keycloak.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-consortia-keycloak.git</developerConnection>
-    <tag>v1.8.1</tag>
+    <tag>v1.8.0</tag>
   </scm>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <groupId>org.folio</groupId>
   <artifactId>mod-consortia-keycloak</artifactId>
   <name>mod-consortia-keycloak</name>
-  <version>1.8.1-SNAPSHOT</version>
+  <version>1.8.1</version>
   <description>Business logic to manage consortia in FOLIO</description>
   <packaging>jar</packaging>
 
@@ -760,7 +760,7 @@
     <url>https://github.com/folio-org/mod-consortia-keycloak</url>
     <connection>scm:git:git://github.com:folio-org/mod-consortia-keycloak.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-consortia-keycloak.git</developerConnection>
-    <tag>v1.8.0</tag>
+    <tag>v1.8.1</tag>
   </scm>
 
   <profiles>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,13 @@ folio:
   okapi-url: ${OKAPI_URL:http://sidecar:8081}
   exchange:
     enabled: true
+  logging:
+    request:
+      enabled: ${FOLIO_LOGGING_REQUEST_ENABLED:false}
+      level: ${FOLIO_LOGGING_REQUEST_LEVEL:BASIC}
+    exchange:
+      enabled: ${FOLIO_LOGGING_EXCHANGE_ENABLED:false}
+      level: ${FOLIO_LOGGING_EXCHANGE_LEVEL:BASIC}
   kafka:
     numberOfPartitions: ${NUMBER_OF_PARTITIONS:1}
     replicationFactor: ${REPLICATION_FACTOR:1}
@@ -120,3 +127,5 @@ management:
 logging:
   level:
     liquibase: info
+    org.folio.spring.filter.IncomingRequestLoggingFilter: DEBUG
+    org.folio.spring.client.ExchangeLoggingInterceptor: DEBUG


### PR DESCRIPTION
## 1.8.1 - Released (Trillium R1 2025)
The purpose of this release is to add possibility to enable http request logging.
[Full Changelog](https://github.com/folio-org/mod-consortia-keycloak/compare/v1.8.0...v1.8.1)

### Stories
* [MODCONSKC-117](https://folio-org.atlassian.net/browse/MODCONSKC-117) - HTTP requests logging configuration