### PR TITLE
MODCONSKC-111. Consortium manager does not load in a new tab/browser during long-running operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,23 +92,29 @@ requires and provides, the permissions, and the additional module metadata.
 
 ### Environment variables
 
-| Name                          | Default value       | Description                                                                                                                                                |
-|:------------------------------|:--------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| DB_HOST                       | postgres            | Postgres hostname                                                                                                                                          |
-| DB_PORT                       | 5432                | Postgres port                                                                                                                                              |
-| DB_USERNAME                   | folio_admin         | Postgres username                                                                                                                                          |
-| DB_PASSWORD                   | -                   | Postgres username password                                                                                                                                 |
-| DB_DATABASE                   | okapi_modules       | Postgres database name                                                                                                                                     |
-| KAFKA_HOST                    | kafka               | Kafka broker hostname                                                                                                                                      |
-| KAFKA_PORT                    | 9092                | Kafka broker port                                                                                                                                          |
-| KAFKA_SECURITY_PROTOCOL       | PLAINTEXT           | Kafka security protocol used to communicate with brokers (SSL or PLAINTEXT)                                                                                |
-| KAFKA_SSL_KEYSTORE_LOCATION   | -                   | The location of the Kafka key store file. This is optional for client and can be used for two-way authentication for client.                               |
-| KAFKA_SSL_KEYSTORE_PASSWORD   | -                   | The store password for the Kafka key store file. This is optional for client and only needed if 'ssl.keystore.location' is configured.                     |
-| KAFKA_SSL_TRUSTSTORE_LOCATION | -                   | The location of the Kafka trust store file.                                                                                                                |
-| KAFKA_SSL_TRUSTSTORE_PASSWORD | -                   | The password for the Kafka trust store file. If a password is not set, trust store file configured will still be used, but integrity checking is disabled. |
-| ENV                           | folio               | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed     |
-| OKAPI_URL                     | http://sidecar:8081 | Okapi url                                                                                                                                                  |
-| SECRET_STORE_TYPE             | EPHEMERAL           | Defines the type of secret store to use.                                                                                                                   |
+| Name                                | Default value       | Description                                                                                                                                                |
+|:------------------------------------|:--------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| DB_HOST                             | postgres            | Postgres hostname                                                                                                                                          |
+| DB_PORT                             | 5432                | Postgres port                                                                                                                                              |
+| DB_USERNAME                         | folio_admin         | Postgres username                                                                                                                                          |
+| DB_PASSWORD                         | -                   | Postgres username password                                                                                                                                 |
+| DB_DATABASE                         | okapi_modules       | Postgres database name                                                                                                                                     |
+| KAFKA_HOST                          | kafka               | Kafka broker hostname                                                                                                                                      |
+| KAFKA_PORT                          | 9092                | Kafka broker port                                                                                                                                          |
+| KAFKA_SECURITY_PROTOCOL             | PLAINTEXT           | Kafka security protocol used to communicate with brokers (SSL or PLAINTEXT)                                                                                |
+| KAFKA_SSL_KEYSTORE_LOCATION         | -                   | The location of the Kafka key store file. This is optional for client and can be used for two-way authentication for client.                               |
+| KAFKA_SSL_KEYSTORE_PASSWORD         | -                   | The store password for the Kafka key store file. This is optional for client and only needed if 'ssl.keystore.location' is configured.                     |
+| KAFKA_SSL_TRUSTSTORE_LOCATION       | -                   | The location of the Kafka trust store file.                                                                                                                |
+| KAFKA_SSL_TRUSTSTORE_PASSWORD       | -                   | The password for the Kafka trust store file. If a password is not set, trust store file configured will still be used, but integrity checking is disabled. |
+| ENV                                 | folio               | Logical name of the deployment, must be set if Kafka/Elasticsearch are shared for environments, `a-z (any case)`, `0-9`, `-`, `_` symbols only allowed     |
+| OKAPI_URL                           | http://sidecar:8081 | Okapi url                                                                                                                                                  |
+| SECRET_STORE_TYPE                   | EPHEMERAL           | Defines the type of secret store to use.                                                                                                                   |
+| ASYNC_EXECUTOR_CORE_POOL_SIZE       | 5                   | Core threads kept alive in the general async executor. Used by `@Async` methods such as Kafka `USER_CREATED/UPDATED/DELETED` listeners and `executeAsyncSystemUserScoped`. |
+| ASYNC_EXECUTOR_MAX_POOL_SIZE        | 10                  | Maximum threads the general async executor may spawn once the queue is full.                                                                               |
+| ASYNC_EXECUTOR_QUEUE_CAPACITY       | 500                 | Bounded queue depth for the general async executor before additional threads are created up to `ASYNC_EXECUTOR_MAX_POOL_SIZE`.                             |
+| PUBLICATION_EXECUTOR_CORE_POOL_SIZE | 5                   | Core threads kept alive in the publication executor that processes per-tenant share/publication fan-out. Isolated from the async pool so long-running HTTP fan-out cannot starve `@Async` handlers. |
+| PUBLICATION_EXECUTOR_MAX_POOL_SIZE  | 10                  | Maximum threads the publication executor may spawn. Aligned with the HikariCP default pool size (10) so threads do not stall waiting on DB connections.    |
+| PUBLICATION_EXECUTOR_QUEUE_CAPACITY | 500                 | Bounded queue depth for the publication executor before additional threads are created up to `PUBLICATION_EXECUTOR_MAX_POOL_SIZE`.                         |
 
 ### Keycloak environment variables
 

--- a/src/main/java/org/folio/consortia/config/AppConfig.java
+++ b/src/main/java/org/folio/consortia/config/AppConfig.java
@@ -6,6 +6,7 @@ import tools.jackson.databind.cfg.DateTimeFeature;
 import org.folio.consortia.domain.converter.ConsortiumConverter;
 import org.folio.consortia.domain.converter.TenantEntityToTenantConverter;
 import org.folio.consortia.domain.converter.UserTenantConverter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,6 +22,24 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @EnableAsync
 public class AppConfig implements WebMvcConfigurer {
 
+  @Value("${folio.async-executor.core-pool-size:5}")
+  private int asyncExecutorCorePoolSize;
+
+  @Value("${folio.async-executor.max-pool-size:10}")
+  private int asyncExecutorMaxPoolSize;
+
+  @Value("${folio.async-executor.queue-capacity:500}")
+  private int asyncExecutorQueueCapacity;
+
+  @Value("${folio.publication-executor.core-pool-size:5}")
+  private int publicationExecutorCorePoolSize;
+
+  @Value("${folio.publication-executor.max-pool-size:10}")
+  private int publicationExecutorMaxPoolSize;
+
+  @Value("${folio.publication-executor.queue-capacity:500}")
+  private int publicationExecutorQueueCapacity;
+
   @Override
   public void addFormatters(FormatterRegistry registry) {
     registry.addConverter(new TenantEntityToTenantConverter());
@@ -28,14 +47,35 @@ public class AppConfig implements WebMvcConfigurer {
     registry.addConverter(new ConsortiumConverter());
   }
 
+  /**
+   * Default executor used by {@code @Async} methods (e.g. Kafka USER_CREATED/UPDATED/DELETED
+   * handlers via {@code executeAsyncSystemUserScoped}). Kept small and isolated from long-running
+   * publication work so user-affiliation processing is not blocked while a large share runs.
+   */
   @Primary
   @Bean("asyncTaskExecutor")
   public TaskExecutor asyncTaskExecutor() {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-    executor.setCorePoolSize(Math.max(1, Runtime.getRuntime().availableProcessors() / 2));
-    executor.setMaxPoolSize(Runtime.getRuntime().availableProcessors() * 2);
-    executor.setQueueCapacity(500);
+    executor.setCorePoolSize(asyncExecutorCorePoolSize);
+    executor.setMaxPoolSize(asyncExecutorMaxPoolSize);
+    executor.setQueueCapacity(asyncExecutorQueueCapacity);
     executor.setThreadNamePrefix("ConsortiaAsync-");
+    executor.initialize();
+    return executor;
+  }
+
+  /**
+   * Dedicated pool for publication fan-out (one task per tenant). Separated from
+   * {@link #asyncTaskExecutor()} so HTTP-bound publication work cannot starve {@code @Async}
+   * consumers.
+   */
+  @Bean("publicationTaskExecutor")
+  public TaskExecutor publicationTaskExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(publicationExecutorCorePoolSize);
+    executor.setMaxPoolSize(publicationExecutorMaxPoolSize);
+    executor.setQueueCapacity(publicationExecutorQueueCapacity);
+    executor.setThreadNamePrefix("ConsortiaPublication-");
     executor.initialize();
     return executor;
   }

--- a/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
@@ -8,11 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletionException;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.log4j.Log4j2;
@@ -43,7 +39,6 @@ import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.data.OffsetRequest;
 import org.folio.spring.scope.FolioExecutionContextSetter;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpMethod;
@@ -63,16 +58,13 @@ public class PublicationServiceImpl implements PublicationService {
   private final FolioExecutionContext folioExecutionContext;
   private final FolioModuleMetadata folioModuleMetadata;
   private final HttpRequestService httpRequestService;
-  private final TaskExecutor asyncTaskExecutor;
+  private final TaskExecutor publicationTaskExecutor;
 
   private final PublicationStatusRepository publicationStatusRepository;
   private final PublicationTenantRequestRepository publicationTenantRequestRepository;
   private final PublicationStorageService publicationStorageService;
   private final ObjectMapper objectMapper;
   private final ConsortiumService consortiumService;
-
-  @Value("${folio.max-active-threads:5}")
-  private int maxActiveThreads;
 
   @Override
   @SneakyThrows
@@ -83,7 +75,7 @@ public class PublicationServiceImpl implements PublicationService {
     var savedEntity = publicationStorageService.savePublicationStatusEntity(createdPublicationEntity);
     log.info("publishRequest:: Publication with id {} and status {} was created", savedEntity.getId(), savedEntity.getStatus());
 
-    asyncTaskExecutor.execute(getRunnableWithCurrentFolioContext(
+    publicationTaskExecutor.execute(getRunnableWithCurrentFolioContext(
       () -> processTenantRequests(publicationRequest, savedEntity.getId())));
 
     return buildPublicationResponse(savedEntity.getId());
@@ -132,41 +124,36 @@ public class PublicationServiceImpl implements PublicationService {
       .toList();
   }
 
-  void processTenantRequests(PublicationRequest publicationRequest, UUID publicationId) {
+  CompletableFuture<Void> processTenantRequests(PublicationRequest publicationRequest, UUID publicationId) {
     var createdPublicationEntity = publicationStatusRepository.findById(publicationId)
       .orElseThrow(() -> new ResourceNotFoundException(PUBLICATION_ID_FIELD, publicationId.toString()));
-    List<Future<PublicationTenantRequestEntity>> futures = new ArrayList<>();
-    ExecutorService executor = Executors.newFixedThreadPool(maxActiveThreads);
+    List<CompletableFuture<PublicationTenantRequestEntity>> futures = new ArrayList<>();
 
-    try {
-      for (String tenantId : publicationRequest.getTenants()) {
-        try {
-          PublicationTenantRequestEntity ptrEntity = buildPublicationRequestEntity(publicationRequest, createdPublicationEntity, tenantId);
-          var savedPublicationTenantRequest = savePublicationTenantRequest(ptrEntity);
-          var future = executor.submit(() -> executeAndUpdatePublicationTenantRequest(publicationRequest, tenantId, savedPublicationTenantRequest));
-          futures.add(future);
-        } catch (Exception e) {
-          log.error("processTenantRequests:: failed to create and submit task for tenant {} and publication id {} ",
-            tenantId, createdPublicationEntity.getId(), e);
-          futures.add(CompletableFuture.failedFuture(e));
-        }
+    for (String tenantId : publicationRequest.getTenants()) {
+      CompletableFuture<PublicationTenantRequestEntity> future = new CompletableFuture<>();
+      futures.add(future);
+      try {
+        PublicationTenantRequestEntity ptrEntity = buildPublicationRequestEntity(publicationRequest, createdPublicationEntity, tenantId);
+        var savedPublicationTenantRequest = savePublicationTenantRequest(ptrEntity);
+        publicationTaskExecutor.execute(getRunnableWithCurrentFolioContext(() -> {
+          try {
+            future.complete(executeAndUpdatePublicationTenantRequest(publicationRequest, tenantId, savedPublicationTenantRequest));
+          } catch (Exception t) {
+            future.completeExceptionally(t);
+          }
+        }));
+      } catch (Exception e) {
+        log.error("processTenantRequests:: failed to create and submit task for tenant {} and publication id {} ",
+          tenantId, createdPublicationEntity.getId(), e);
+        future.completeExceptionally(e);
       }
-    } finally {
-      executor.shutdown();
     }
 
-    try {
-      if (!executor.awaitTermination(300, TimeUnit.SECONDS)) {
-        log.warn("processTenantRequests:: Publication tasks timed out. Forcing shutdown. Publication id: {}", createdPublicationEntity.getId());
-        executor.shutdownNow();
-      }
-    } catch (InterruptedException e) {
-      log.error("Publication task executor was interrupted. Forcing shutdown. Publication id: {}", createdPublicationEntity.getId(), e);
-      executor.shutdownNow();
-      Thread.currentThread().interrupt();
-    } finally {
-      updatePublicationsStatus(futures, createdPublicationEntity);
-    }
+    Runnable statusUpdate = getRunnableWithCurrentFolioContext(
+      () -> updatePublicationsStatus(futures, createdPublicationEntity));
+
+    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+      .whenComplete((v, t) -> statusUpdate.run());
   }
 
   PublicationTenantRequestEntity executeAndUpdatePublicationTenantRequest(PublicationRequest publicationRequest, String tenantId,
@@ -259,17 +246,14 @@ public class PublicationServiceImpl implements PublicationService {
     return publicationStatusEntity;
   }
 
-  private void updatePublicationsStatus(List<Future<PublicationTenantRequestEntity>> futures, PublicationStatusEntity publicationStatusEntity) {
+  private void updatePublicationsStatus(List<CompletableFuture<PublicationTenantRequestEntity>> futures, PublicationStatusEntity publicationStatusEntity) {
     List<PublicationTenantRequestEntity> ptreList = new ArrayList<>();
     futures.forEach(future -> {
       try {
-        var ptre = future.get();
-        ptreList.add(ptre);
-      } catch (InterruptedException e) {
-        // Will never occur. All executor threads are safely completed at this point
-        Thread.currentThread().interrupt();
-      } catch (ExecutionException e) {
-        log.error("updatePublicationsStatus:: publication tenant request failed", e);
+        ptreList.add(future.join());
+      } catch (CompletionException e) {
+        log.error("updatePublicationsStatus:: publication tenant request failed for publication {}",
+          publicationStatusEntity.getId(), e);
       }
     });
     var isCompletedWithExceptions = futures.size() != ptreList.size();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,14 @@ folio:
   okapi-url: ${OKAPI_URL:http://sidecar:8081}
   exchange:
     enabled: true
+  async-executor:
+    core-pool-size: ${ASYNC_EXECUTOR_CORE_POOL_SIZE:5}
+    max-pool-size: ${ASYNC_EXECUTOR_MAX_POOL_SIZE:10}
+    queue-capacity: ${ASYNC_EXECUTOR_QUEUE_CAPACITY:500}
+  publication-executor:
+    core-pool-size: ${PUBLICATION_EXECUTOR_CORE_POOL_SIZE:5}
+    max-pool-size: ${PUBLICATION_EXECUTOR_MAX_POOL_SIZE:10}
+    queue-capacity: ${PUBLICATION_EXECUTOR_QUEUE_CAPACITY:500}
   logging:
     request:
       enabled: ${FOLIO_LOGGING_REQUEST_ENABLED:false}
@@ -80,7 +88,6 @@ folio:
     lastname: SystemConsortia
   timer:
     publication-records-max-age-in-seconds: 86400
-  max-active-threads: 5
 application:
   secret-store:
     environment: ${SECURE_STORE_ENV:${ENV:folio}}

--- a/src/test/java/org/folio/consortia/service/impl/PublicationServiceImplTest.java
+++ b/src/test/java/org/folio/consortia/service/impl/PublicationServiceImplTest.java
@@ -24,6 +24,7 @@ import org.folio.consortia.domain.dto.PublicationRequest;
 import org.folio.consortia.domain.dto.PublicationStatus;
 import org.folio.consortia.domain.entity.PublicationStatusEntity;
 import org.folio.consortia.domain.entity.PublicationTenantRequestEntity;
+import org.folio.consortia.exception.PublicationException;
 import org.folio.consortia.exception.ResourceNotFoundException;
 import org.folio.consortia.repository.PublicationStatusRepository;
 import org.folio.consortia.repository.PublicationTenantRequestRepository;
@@ -152,6 +153,38 @@ class PublicationServiceImplTest extends BaseUnitTest {
     verify(publicationStatusRepository).save(pseCaptor.capture());
     PublicationStatusEntity capturedStatusEntity = pseCaptor.getValue();
     assertEquals(PublicationStatus.ERROR, capturedStatusEntity.getStatus());
+  }
+
+  @Test
+  void processTenantRequests_shouldThrowWhenPublicationNotFound() {
+    var publicationRequest = getMockDataObject(PUBLICATION_REQUEST_SAMPLE, PublicationRequest.class);
+    var missingPublicationId = UUID.randomUUID();
+
+    when(publicationStatusRepository.findById(missingPublicationId)).thenReturn(Optional.empty());
+
+    assertThrows(ResourceNotFoundException.class,
+      () -> publicationService.processTenantRequests(publicationRequest, missingPublicationId));
+  }
+
+  @Test
+  void processTenantRequests_shouldMarkPublicationErrorOnSubmissionFailure() {
+    var publicationRequest = getMockDataObject(PUBLICATION_REQUEST_SAMPLE, PublicationRequest.class);
+    var publicationStatusEntity = getMockDataObject(PUBLICATION_STATUS_ENTITY_SAMPLE, PublicationStatusEntity.class);
+    var payload = "{\"id\":\"123\"}";
+
+    when(folioExecutionContext.getInstance()).thenReturn(folioExecutionContext);
+    when(objectMapper.writeValueAsString(any())).thenReturn(payload);
+    when(publicationStatusRepository.findById(any())).thenReturn(Optional.of(publicationStatusEntity));
+    when(publicationTenantRequestRepository.save(any(PublicationTenantRequestEntity.class)))
+      .thenThrow(new PublicationException(new RuntimeException("db down")));
+
+    try (var ignored = new FolioExecutionContextSetter(folioExecutionContext)) {
+      publicationService.processTenantRequests(publicationRequest, publicationStatusEntity.getId())
+        .exceptionally(t -> null).join();
+    }
+
+    verify(publicationStatusRepository).save(pseCaptor.capture());
+    assertEquals(PublicationStatus.ERROR, pseCaptor.getValue().getStatus());
   }
 
   @Test

--- a/src/test/java/org/folio/consortia/service/impl/PublicationServiceImplTest.java
+++ b/src/test/java/org/folio/consortia/service/impl/PublicationServiceImplTest.java
@@ -41,7 +41,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -72,9 +73,8 @@ class PublicationServiceImplTest extends BaseUnitTest {
   private UserTenantService userTenantService;
   @MockitoBean
   private TenantService tenantService;
-  @MockitoBean
-  private AsyncTaskExecutor asyncTaskExecutor;
 
+  private TaskExecutor publicationTaskExecutor;
   private ArgumentCaptor<PublicationStatusEntity> pseCaptor;
   private ArgumentCaptor<PublicationTenantRequestEntity> ptreCaptor;
 
@@ -82,7 +82,8 @@ class PublicationServiceImplTest extends BaseUnitTest {
   void setup() {
     pseCaptor = ArgumentCaptor.forClass(PublicationStatusEntity.class);
     ptreCaptor = ArgumentCaptor.forClass(PublicationTenantRequestEntity.class);
-    ReflectionTestUtils.setField(publicationService, "asyncTaskExecutor", asyncTaskExecutor);
+    publicationTaskExecutor = Mockito.spy(new SyncTaskExecutor());
+    ReflectionTestUtils.setField(publicationService, "publicationTaskExecutor", publicationTaskExecutor);
   }
 
   @Test
@@ -96,13 +97,13 @@ class PublicationServiceImplTest extends BaseUnitTest {
     when(userTenantService.checkUserIfHasPrimaryAffiliationByUserId(any(), anyString())).thenReturn(true);
     when(folioExecutionContext.getInstance()).thenReturn(folioExecutionContext);
     when(publicationStorageService.savePublicationStatusEntity(any(PublicationStatusEntity.class))).thenReturn(publicationStatusEntity);
-    doNothing().when(asyncTaskExecutor).execute(any(Runnable.class));
+    doNothing().when(publicationTaskExecutor).execute(any(Runnable.class));
 
     try (var ignored = new FolioExecutionContextSetter(folioExecutionContext)) {
       var response = publicationService.publishRequest(consortiumId, publicationRequest);
 
       verify(publicationStorageService).savePublicationStatusEntity(any(PublicationStatusEntity.class));
-      verify(asyncTaskExecutor).execute(any(Runnable.class));
+      verify(publicationTaskExecutor).execute(any(Runnable.class));
 
       Assertions.assertEquals(publicationStatusEntity.getId(), response.getId());
       Assertions.assertEquals(PublicationStatus.IN_PROGRESS, response.getStatus());
@@ -115,14 +116,16 @@ class PublicationServiceImplTest extends BaseUnitTest {
     var publicationStatusEntity = getMockDataObject(PUBLICATION_STATUS_ENTITY_SAMPLE, PublicationStatusEntity.class);
     var payload = "{\"id\":\"123\"}";
 
-    ReflectionTestUtils.setField(publicationService, "maxActiveThreads", 1);
+    when(folioExecutionContext.getInstance()).thenReturn(folioExecutionContext);
     when(objectMapper.writeValueAsString(any())).thenReturn(payload);
     when(publicationTenantRequestRepository.save(any(PublicationTenantRequestEntity.class))).thenAnswer(inv -> inv.getArgument(0));
     when(publicationStatusRepository.findById(any())).thenReturn(Optional.of(publicationStatusEntity));
     when(httpRequestService.performRequest(anyString(), eq(HttpMethod.POST), any()))
       .thenReturn(new PublicationHttpResponse(payload, HttpStatusCode.valueOf(201)));
 
-    publicationService.processTenantRequests(publicationRequest, publicationStatusEntity.getId());
+    try (var ignored = new FolioExecutionContextSetter(folioExecutionContext)) {
+      publicationService.processTenantRequests(publicationRequest, publicationStatusEntity.getId()).join();
+    }
 
     verify(publicationStatusRepository).save(pseCaptor.capture());
     PublicationStatusEntity capturedStatusEntity = pseCaptor.getValue();
@@ -135,14 +138,16 @@ class PublicationServiceImplTest extends BaseUnitTest {
     var publicationStatusEntity = getMockDataObject(PUBLICATION_STATUS_ENTITY_SAMPLE, PublicationStatusEntity.class);
     var payload = "{\"id\":\"123\"}";
 
-    ReflectionTestUtils.setField(publicationService, "maxActiveThreads", 1);
+    when(folioExecutionContext.getInstance()).thenReturn(folioExecutionContext);
     when(objectMapper.writeValueAsString(any())).thenReturn(payload);
     when(publicationTenantRequestRepository.save(any(PublicationTenantRequestEntity.class))).thenAnswer(inv -> inv.getArgument(0));
     when(publicationStatusRepository.findById(any())).thenReturn(Optional.of(publicationStatusEntity));
     when(httpRequestService.performRequest(anyString(), eq(HttpMethod.POST), any()))
       .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
 
-    publicationService.processTenantRequests(publicationRequest, publicationStatusEntity.getId());
+    try (var ignored = new FolioExecutionContextSetter(folioExecutionContext)) {
+      publicationService.processTenantRequests(publicationRequest, publicationStatusEntity.getId()).join();
+    }
 
     verify(publicationStatusRepository).save(pseCaptor.capture());
     PublicationStatusEntity capturedStatusEntity = pseCaptor.getValue();

--- a/src/test/java/org/folio/consortia/service/impl/SyncPrimaryAffiliationServiceImplTest.java
+++ b/src/test/java/org/folio/consortia/service/impl/SyncPrimaryAffiliationServiceImplTest.java
@@ -68,7 +68,7 @@ class SyncPrimaryAffiliationServiceImplTest {
   private ConsortiaConfigurationService consortiaConfigurationService;
   @MockitoBean
   private LockService lockService;
-  @MockitoSpyBean
+  @MockitoSpyBean(name = "asyncTaskExecutor")
   private TaskExecutor asyncTaskExecutor = new SimpleAsyncTaskExecutor();
 
   private SyncPrimaryAffiliationServiceImpl syncPrimaryAffiliationService;


### PR DESCRIPTION
## Problem         

  When a role with many capability sets was shared across all member tenants ("Share to all"), the Consortium Manager app failed to load in a second tab/browser, and newly created
   users were not assigned affiliations until the share completed.

## Root cause

The same asyncTaskExecutor thread pool was used for two unrelated concerns:
  1. Publication fan-out — PublicationServiceImpl.processTenantRequests allocated an ad-hoc Executors.newFixedThreadPool(...) per publication and then blocked the calling thread
  via awaitTermination(300s). The caller is itself an asyncTaskExecutor thread.
  2. Kafka USER_CREATED/UPDATED/DELETED event handlers — wired through @Async / executeAsyncSystemUserScoped, which also use asyncTaskExecutor.

In containerized environments, Runtime.getRuntime().availableProcessors() reports the cgroup CPU limit, so the original core=cpu/2, max=cpu*2 defaults gave only 1–2 worker
  threads in prod. A single large share would pin all of them for minutes, starving user-affiliation processing and any UI request relying on the same pool.

##  Fix

  - Separate publicationTaskExecutor bean isolated from asyncTaskExecutor. Kafka user events can no longer be blocked by publication work.
  - Non-blocking processTenantRequests — replaced the per-publication thread pool + awaitTermination with a CompletableFuture chain (allOf(...).whenComplete(statusUpdate)). Each
  pool thread now serves one tenant HTTP call, not one whole publication.
  - Configurable pool sizes via env vars (sensible defaults: core=5, max=10, queue=500, aligned with HikariCP).
  - README updated with the new env vars.
