### PR TITLE
MODCONSKC-111. Consortium manager does not load in a new tab/browser during long-running operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,12 @@ requires and provides, the permissions, and the additional module metadata.
 | ASYNC_EXECUTOR_CORE_POOL_SIZE       | 5                   | Core threads kept alive in the general async executor. Used by `@Async` methods such as Kafka `USER_CREATED/UPDATED/DELETED` listeners and `executeAsyncSystemUserScoped`. |
 | ASYNC_EXECUTOR_MAX_POOL_SIZE        | 10                  | Maximum threads the general async executor may spawn once the queue is full.                                                                               |
 | ASYNC_EXECUTOR_QUEUE_CAPACITY       | 500                 | Bounded queue depth for the general async executor before additional threads are created up to `ASYNC_EXECUTOR_MAX_POOL_SIZE`.                             |
-| PUBLICATION_EXECUTOR_CORE_POOL_SIZE | 5                   | Core threads kept alive in the publication executor that processes per-tenant share/publication fan-out. Isolated from the async pool so long-running HTTP fan-out cannot starve `@Async` handlers. |
+| PUBLICATION_EXECUTOR_CORE_POOL_SIZE | 5                   | Core threads kept alive in the publication executor that processes per-tenant write share/publication fan-out (POST/PUT/DELETE). Isolated from the async pool so long-running HTTP fan-out cannot starve `@Async` handlers. |
 | PUBLICATION_EXECUTOR_MAX_POOL_SIZE  | 10                  | Maximum threads the publication executor may spawn. Aligned with the HikariCP default pool size (10) so threads do not stall waiting on DB connections.    |
 | PUBLICATION_EXECUTOR_QUEUE_CAPACITY | 500                 | Bounded queue depth for the publication executor before additional threads are created up to `PUBLICATION_EXECUTOR_MAX_POOL_SIZE`.                         |
+| GET_PUBLICATION_EXECUTOR_CORE_POOL_SIZE | 5               | Core threads kept alive in the GET publication executor (read fan-out across member tenants, e.g. listing settings). Isolated from the write publication pool so UI reads are not queued behind long-running write shares. |
+| GET_PUBLICATION_EXECUTOR_MAX_POOL_SIZE  | 10              | Maximum threads the GET publication executor may spawn.                                                                                                    |
+| GET_PUBLICATION_EXECUTOR_QUEUE_CAPACITY | 500             | Bounded queue depth for the GET publication executor before additional threads are created up to `GET_PUBLICATION_EXECUTOR_MAX_POOL_SIZE`.                 |
 
 ### Keycloak environment variables
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1138,6 +1138,42 @@
       {
         "name": "ENV",
         "value": "folio"
+      },
+      {
+        "name": "ASYNC_EXECUTOR_CORE_POOL_SIZE",
+        "value": "5"
+      },
+      {
+        "name": "ASYNC_EXECUTOR_MAX_POOL_SIZE",
+        "value": "10"
+      },
+      {
+        "name": "ASYNC_EXECUTOR_QUEUE_CAPACITY",
+        "value": "500"
+      },
+      {
+        "name": "PUBLICATION_EXECUTOR_CORE_POOL_SIZE",
+        "value": "5"
+      },
+      {
+        "name": "PUBLICATION_EXECUTOR_MAX_POOL_SIZE",
+        "value": "10"
+      },
+      {
+        "name": "PUBLICATION_EXECUTOR_QUEUE_CAPACITY",
+        "value": "500"
+      },
+      {
+        "name": "GET_PUBLICATION_EXECUTOR_CORE_POOL_SIZE",
+        "value": "5"
+      },
+      {
+        "name": "GET_PUBLICATION_EXECUTOR_MAX_POOL_SIZE",
+        "value": "10"
+      },
+      {
+        "name": "GET_PUBLICATION_EXECUTOR_QUEUE_CAPACITY",
+        "value": "500"
       }
     ]
   }

--- a/src/main/java/org/folio/consortia/config/AppConfig.java
+++ b/src/main/java/org/folio/consortia/config/AppConfig.java
@@ -40,6 +40,15 @@ public class AppConfig implements WebMvcConfigurer {
   @Value("${folio.publication-executor.queue-capacity:500}")
   private int publicationExecutorQueueCapacity;
 
+  @Value("${folio.get-publication-executor.core-pool-size:5}")
+  private int getPublicationExecutorCorePoolSize;
+
+  @Value("${folio.get-publication-executor.max-pool-size:10}")
+  private int getPublicationExecutorMaxPoolSize;
+
+  @Value("${folio.get-publication-executor.queue-capacity:500}")
+  private int getPublicationExecutorQueueCapacity;
+
   @Override
   public void addFormatters(FormatterRegistry registry) {
     registry.addConverter(new TenantEntityToTenantConverter());
@@ -65,9 +74,9 @@ public class AppConfig implements WebMvcConfigurer {
   }
 
   /**
-   * Dedicated pool for publication fan-out (one task per tenant). Separated from
-   * {@link #asyncTaskExecutor()} so HTTP-bound publication work cannot starve {@code @Async}
-   * consumers.
+   * Dedicated pool for write publication fan-out (POST/PUT/DELETE, one task per tenant).
+   * Separated from {@link #asyncTaskExecutor()} so HTTP-bound publication work cannot starve
+   * {@code @Async} consumers.
    */
   @Bean("publicationTaskExecutor")
   public TaskExecutor publicationTaskExecutor() {
@@ -76,6 +85,22 @@ public class AppConfig implements WebMvcConfigurer {
     executor.setMaxPoolSize(publicationExecutorMaxPoolSize);
     executor.setQueueCapacity(publicationExecutorQueueCapacity);
     executor.setThreadNamePrefix("ConsortiaPublication-");
+    executor.initialize();
+    return executor;
+  }
+
+  /**
+   * Dedicated pool for read publication fan-out (GET, one task per tenant). Separated from
+   * {@link #publicationTaskExecutor()} so interactive UI reads (e.g. listing settings across
+   * member tenants) are not queued behind long-running write shares.
+   */
+  @Bean("getPublicationTaskExecutor")
+  public TaskExecutor getPublicationTaskExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(getPublicationExecutorCorePoolSize);
+    executor.setMaxPoolSize(getPublicationExecutorMaxPoolSize);
+    executor.setQueueCapacity(getPublicationExecutorQueueCapacity);
+    executor.setThreadNamePrefix("ConsortiaGetPublication-");
     executor.initialize();
     return executor;
   }

--- a/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
+++ b/src/main/java/org/folio/consortia/service/impl/PublicationServiceImpl.java
@@ -39,6 +39,7 @@ import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.data.OffsetRequest;
 import org.folio.spring.scope.FolioExecutionContextSetter;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpMethod;
@@ -58,7 +59,10 @@ public class PublicationServiceImpl implements PublicationService {
   private final FolioExecutionContext folioExecutionContext;
   private final FolioModuleMetadata folioModuleMetadata;
   private final HttpRequestService httpRequestService;
+  @Qualifier("publicationTaskExecutor")
   private final TaskExecutor publicationTaskExecutor;
+  @Qualifier("getPublicationTaskExecutor")
+  private final TaskExecutor getPublicationTaskExecutor;
 
   private final PublicationStatusRepository publicationStatusRepository;
   private final PublicationTenantRequestRepository publicationTenantRequestRepository;
@@ -75,10 +79,16 @@ public class PublicationServiceImpl implements PublicationService {
     var savedEntity = publicationStorageService.savePublicationStatusEntity(createdPublicationEntity);
     log.info("publishRequest:: Publication with id {} and status {} was created", savedEntity.getId(), savedEntity.getStatus());
 
-    publicationTaskExecutor.execute(getRunnableWithCurrentFolioContext(
+    executorFor(publicationRequest).execute(getRunnableWithCurrentFolioContext(
       () -> processTenantRequests(publicationRequest, savedEntity.getId())));
 
     return buildPublicationResponse(savedEntity.getId());
+  }
+
+  private TaskExecutor executorFor(PublicationRequest publicationRequest) {
+    return HttpMethod.GET.matches(publicationRequest.getMethod())
+      ? getPublicationTaskExecutor
+      : publicationTaskExecutor;
   }
 
   @Override
@@ -135,7 +145,7 @@ public class PublicationServiceImpl implements PublicationService {
       try {
         PublicationTenantRequestEntity ptrEntity = buildPublicationRequestEntity(publicationRequest, createdPublicationEntity, tenantId);
         var savedPublicationTenantRequest = savePublicationTenantRequest(ptrEntity);
-        publicationTaskExecutor.execute(getRunnableWithCurrentFolioContext(() -> {
+        executorFor(publicationRequest).execute(getRunnableWithCurrentFolioContext(() -> {
           try {
             future.complete(executeAndUpdatePublicationTenantRequest(publicationRequest, tenantId, savedPublicationTenantRequest));
           } catch (Exception t) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,10 @@ folio:
     core-pool-size: ${PUBLICATION_EXECUTOR_CORE_POOL_SIZE:5}
     max-pool-size: ${PUBLICATION_EXECUTOR_MAX_POOL_SIZE:10}
     queue-capacity: ${PUBLICATION_EXECUTOR_QUEUE_CAPACITY:500}
+  get-publication-executor:
+    core-pool-size: ${GET_PUBLICATION_EXECUTOR_CORE_POOL_SIZE:5}
+    max-pool-size: ${GET_PUBLICATION_EXECUTOR_MAX_POOL_SIZE:10}
+    queue-capacity: ${GET_PUBLICATION_EXECUTOR_QUEUE_CAPACITY:500}
   logging:
     request:
       enabled: ${FOLIO_LOGGING_REQUEST_ENABLED:false}


### PR DESCRIPTION
MODCONSKC-111: Consortium Manager does not load in a new tab during long-running operations                                                                                                                                      
                                                                                                                                                                                                                                   
Problem                                                                                                                                                                                                                          
                                                                                                                                                                                                                                   
  When a role with many capability sets was shared across all member tenants ("Share to all"):                                                                                                                                     
  - Consortium Manager failed to load in a second tab/browser
  - Newly created users were not assigned affiliations until the share completed                                                                                                                                                   
  - Opening any Consortium Manager screen that fans out reads to member tenants (e.g. Inventory Settings) hung until the share completed                                                                                           
                                                                                                                                                                                                                                   
Root cause

  A single shared thread pool (asyncTaskExecutor) handled three unrelated workloads:
  1. Publication fan-out (HTTP calls to member tenants for share/publish operations)
  2. Kafka USER_CREATED/UPDATED/DELETED event handlers via @Async
  3. Both write fan-out (POST/PUT/DELETE) and read fan-out (GET) publications

Fix

  - Three isolated thread pools with explicit @Qualifier wiring:
    - asyncTaskExecutor (ConsortiaAsync-*) — Kafka @Async handlers
    - publicationTaskExecutor (ConsortiaPublication-*) — write publications (POST/PUT/DELETE)
    - getPublicationTaskExecutor (ConsortiaGetPublication-*) — read publications (GET, e.g. Inventory Settings fan-out)

  - Configurable pool sizes via env vars with sensible defaults (core=5, max=10, queue=500).